### PR TITLE
update test to include HTTP PATCH

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,15 +12,15 @@
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
   :jvm-opts ["-Dclojure.compiler.disable-locals-clearing=true"]
-  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}
+  :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
              :dev {:dependencies [[junit/junit "4.8.2"]
-                                  [org.clojure/tools.logging "0.2.3"]
-                                  [ch.qos.logback/logback-classic "1.0.1"]
-                                  [clj-http "0.6.0"]
+                                  [org.clojure/tools.logging "0.2.6"]
+                                  [ch.qos.logback/logback-classic "1.0.9"]
+                                  [clj-http "0.6.5"]
                                   [io.netty/netty "3.6.2.Final"]
-                                  [org.clojure/data.json "0.1.2"]
+                                  [org.clojure/data.json "0.2.1"]
                                   [http.async.client "0.5.2"]
-                                  [compojure "1.0.2"]
-                                  [org.clojure/tools.cli "0.2.1"]
-                                  [ring/ring-jetty-adapter "1.1.6"]
-                                  [ring/ring-core "1.1.6"]]}})
+                                  [compojure "1.1.5"]
+                                  [org.clojure/tools.cli "0.2.2"]
+                                  [ring/ring-jetty-adapter "1.1.8"]
+                                  [ring/ring-core "1.1.8"]]}})

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -3,7 +3,7 @@
         [ring.adapter.jetty :only [run-jetty]]
         [org.httpkit.server :only [run-server]]
         org.httpkit.test-util
-        (compojure [core :only [defroutes GET PUT DELETE POST HEAD DELETE ANY context]]
+        (compojure [core :only [defroutes GET PUT PATCH DELETE POST HEAD DELETE ANY context]]
                    [handler :only [site]]
                    [route :only [not-found]])
         (clojure.tools [logging :only [info warn]]))
@@ -14,6 +14,7 @@
 (defroutes test-routes
   (GET "/get" [] "hello world")
   (POST "/post" [] "hello world")
+  (PATCH "/patch" [] "hello world")
   (ANY "/method" [] (fn [req]
                       (let [m (:request-method req)]
                         {:status 200
@@ -55,6 +56,9 @@
     (is (= 200 (:status @(http/post (str host "/post") (fn [resp]
                                                          (is (= 200 (:status resp)))
                                                          resp)))))
+    (is (= 200 (:status @(http/patch (str host "/patch") (fn [resp]
+                                                          (is (= 200 (:status resp)))
+                                                          resp)))))
     (is (= 200 (:status @(http/delete (str host "/delete")))))
     (is (= 200 (:status @(http/head (str host "/get")))))
     (is (= 200 (:status @(http/post (str host "/post")))))


### PR DESCRIPTION
untested updates to include HTTP PATCH in tests to make support more explicit.

can't currently test due to an unrelated error when running `lein test`:

```
Exception in thread "main" java.lang.ClassNotFoundException: org.httpkit.SpecialHttpClient
```
