### PR TITLE
Bug fix for race in AsyncChannel

### DIFF
--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -196,8 +196,8 @@ public class AsyncChannel {
             if (isHeaderSent) {
                 writeChunk(data, close);
             } else {
-                firstWrite(data, close);
                 isHeaderSent = true;
+                firstWrite(data, close);
             }
         }
         return true;


### PR DESCRIPTION
I could reproduce this problem at will.

The async handler would write a response to the channel, the client would immediately send the next request, the server loop would then call reset(), and finally the original handler would clobber headersSent.

Consequently the next response sent was missing its headers.
