### PR TITLE
IPv6 Requests fail with Exception

### DIFF
--- a/src/java/org/httpkit/server/HttpRequest.java
+++ b/src/java/org/httpkit/server/HttpRequest.java
@@ -75,7 +75,7 @@ public class HttpRequest {
     public void setHeaders(Map<String, String> headers) {
         String h = headers.get("host");
         if (h != null) {
-            int idx = h.indexOf(':');
+            int idx = h.lastIndexOf(':');
             if (idx != -1) {
                 this.serverName = h.substring(0, idx);
                 serverPort = Integer.valueOf(h.substring(idx + 1));


### PR DESCRIPTION
When making a request to a http-kit server via IPv6 the request fails with an exception

```
Mon Apr 15 11:51:07 CEST 2013 [server-loop] ERROR - http server loop error, should not happen
java.lang.NumberFormatException: For input string: "xxxx:xxxx]:8000"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:492)
    at java.lang.Integer.valueOf(Integer.java:582)
    at org.httpkit.server.HttpRequest.setHeaders(HttpRequest.java:81)
    at org.httpkit.server.RequestDecoder.readHeaders(RequestDecoder.java:166)
    at org.httpkit.server.RequestDecoder.decode(RequestDecoder.java:89)
    at org.httpkit.server.HttpServer.decodeHttp(HttpServer.java:84)
    at org.httpkit.server.HttpServer.doRead(HttpServer.java:153)
    at org.httpkit.server.HttpServer.run(HttpServer.java:229)
    at java.lang.Thread.run(Thread.java:722) 
```

I have not made any extensive IPv6 tests but at least the request gets served properly when port parsing is done via .lastIndexOf.
