### PR TITLE
Http10 decoder bug

### DIFF
--- a/src/java/org/httpkit/client/Decoder.java
+++ b/src/java/org/httpkit/client/Decoder.java
@@ -49,13 +49,16 @@ public class Decoder {
         cStart = findNonWhitespace(sb, bEnd);
         cEnd = findEndOfString(sb);
 
-        if (cStart < cEnd) {
+        if ((cStart < cEnd)
+                // Account for buggy web servers that omit Reason-Phrase from Status-Line.
+                // http://www.w3.org/Protocols/HTTP/1.0/draft-ietf-http-spec.html#Response
+            || (cStart == cEnd && bStart < bEnd)){
             try {
                 int status = Integer.parseInt(sb.substring(bStart, bEnd));
                 HttpStatus s = HttpStatus.valueOf(status);
 
                 HttpVersion version = HTTP_1_1;
-                if ("HTTP/1.0".equals(sb.substring(aStart, cEnd))) {
+                if ("HTTP/1.0".equals(sb.substring(aStart, aEnd))) {
                     version = HTTP_1_0;
                 }
 


### PR DESCRIPTION
There is a little bug I found in the Status-Line parser code.

HTTP/1.0 was not detected correctly.

The other issue was where a buggy web server returned no Reason-Phrase that resulted in a ProtocolException.

Both should be fixed, tested with GET against 100 different .de domains along with following redirects.

(See buggy web server: http://www.westfalia.de/)
