### PR TITLE
Do not add Accept header if one is already defined for the request

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -240,8 +240,9 @@ public final class HttpClient implements Runnable {
         // copy to modify, normalize header
         HeaderMap headers = HeaderMap.camelCase(cfg.headers);
         headers.put("Host", HttpUtils.getHost(uri));
-        headers.put("Accept", "*/*");
 
+        if (!headers.containsKey("Accept")) // allow override
+            headers.put("Accept", "*/*");
         if (!headers.containsKey("User-Agent")) // allow override
             headers.put("User-Agent", RequestConfig.DEFAULT_USER_AGENT); // default
         if (!headers.containsKey("Accept-Encoding"))


### PR DESCRIPTION
Sometimes when I'm making an HTTP request, I like to specify which content-types I support in the Accept header so a web service doesn't return a type I don't support.

Right now, http-kit just adds an `Accept: */*` header despite me setting it to a different value when creating the request. This pull request checks to see if the accept header is already defined for the request and if it is, not to add an additional one that accepts everything. If an accept header is not specified, then an accept everything header is added.
