### PR TITLE
Graceful shutdown of RingHandler to finish in-flight requests

### DIFF
--- a/src/java/org/httpkit/server/RingHandler.java
+++ b/src/java/org/httpkit/server/RingHandler.java
@@ -171,6 +171,19 @@ public class RingHandler implements IHandler {
         execs.shutdownNow();
     }
 
+    public void gracefulClose(long timeoutMillis) {
+        execs.shutdown();
+        try {
+            if (!execs.awaitTermination(timeoutMillis, TimeUnit.MILLISECONDS)) {
+                execs.shutdownNow();
+            }
+        }
+        catch (InterruptedException ie) {
+            execs.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
     public void handle(AsyncChannel channel, Frame frame) {
         WSHandler task = new WSHandler(channel, frame);
 

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -21,7 +21,11 @@
   (let [h (RingHandler. thread handler worker-name-prefix queue-size)
         s (HttpServer. ip port h max-body max-line)]
     (.start s)
-    (fn stop-server [] (.close h) (.stop s))))
+    (fn stop-server [& {:keys [graceful-timeout]}]
+      (if graceful-timeout
+        (.gracefulClose h graceful-timeout)
+        (.close h))
+      (.stop s))))
 
 ;;;; Asynchronous extension
 


### PR DESCRIPTION
I'm not at all familiar with http-kit so this could be entirely wrong.

My approach is to shutdown the RingHandler's ExecutorService and wait a number of milliseconds for existing threads to terminate before performing a shutdownNow.

I haven't touched the HttpServer itself, since org.httpkit.server/run-server keeps a reference to the RingHandler and calls close on it first anyway.
