### PR TITLE
client/request shouldn't require a callback

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -145,7 +145,7 @@
          response (promise)
          keepalive 120000
          as :auto}}
-   callback]
+   & [callback]]
   (let [{:keys [url method headers body sslengine]} (coerce-req opts)
         deliver-resp #(deliver response ;; deliver the result
                                (try ((or callback identity) %1)


### PR DESCRIPTION
The docs and examples for client/request assert that the callback is optional, but this is not actually the case. Note that this also applies to the documentation found at http://http-kit.org/client.html#options
