### PR TITLE
Fixed :multipart clobbering Authorization, User-Agent headers

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -73,11 +73,11 @@
     (if multipart
       (let [entities (map (fn [{:keys [name content filename]}]
                             (MultipartEntity. name content filename)) multipart)
-            boudary (MultipartEntity/genBoundary entities)]
-        (assoc r
-          :headers (assoc (:headers req)
-                     "Content-Type" (str "multipart/form-data; boundary=" boudary))
-          :body    (MultipartEntity/encode boudary entities)))
+            boundary (MultipartEntity/genBoundary entities)]
+        (-> r
+            (assoc-in [:headers "Content-Type"]
+                      (str "multipart/form-data; boundary=" boundary))
+            (assoc :body (MultipartEntity/encode boundary entities))))
       r)))
 
 ;; thread pool for executing callbacks, since they may take a long time to execute.

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -297,6 +297,16 @@
                                   {:multipart [{:name "comment" :content "httpkit's project.clj"}
                                                {:name "file" :content (clojure.java.io/file "project.clj") :filename "project.clj"}]})))))
 
+
+(deftest test-coerce-req
+  "Headers should be the same regardless of multipart"
+  (let [coerce-req #'org.httpkit.client/coerce-req
+        request {:basic-auth ["user" "pass"]}]
+    (is (= (keys (:headers (coerce-req request)))
+           (remove #(= % "Content-Type")
+                   (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}])))))))))
+
+
 (deftest test-header-multiple-values
   (let [resp @(http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}})
         resp2 (clj-http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}})]


### PR DESCRIPTION
Supplying the :multipart option caused a conditional branch
in coerce-req to be followed which failed to retain the work
done by prepare-request-headers earlier in the function.

The association of the new Content-Type value was also
simplified by using assoc-in. Added a test for the private
coerce-req to expose the issue and verify the fix.

Signed-off-by: Christian Romney cromney@pointslope.com
