### PR TITLE
Server can now respond to HTTP_1.1/Expect : 100-continue header 

### DIFF
--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -85,6 +85,11 @@ public class HttpUtils {
     // space ' '
     public static final byte SP = 32;
 
+    public static final String EXPECT = "expect";
+
+    public static final String CONTINUE = "100-continue";
+
+
     public static ByteBuffer bodyBuffer(Object body) throws IOException {
         if (body == null) {
             return null;

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -66,6 +66,12 @@ public class HttpDecoder {
         }
     }
 
+    public boolean requiresContinue() {
+        String expect = (String) headers.get(EXPECT);
+        return (request != null && request.version == HTTP_1_1 &&
+            expect != null && CONTINUE.equalsIgnoreCase(expect));
+    }
+
     public HttpRequest decode(ByteBuffer buffer) throws LineTooLargeException,
             ProtocolException, RequestTooLargeException {
         String line;


### PR DESCRIPTION
Whenever cURL sends a POST request (on Mac and Linux), it sends the expect header, and then waits 1 second before sending the actual body. This fix allows the server to respond with the correct temporary status code (100) and accelerate the transfer of the body.

> POST / HTTP/1.1
> User-Agent: curl/7.21.4 (universal-apple-darwin11.0) libcurl/7.21.4 OpenSSL/0.9.8y zlib/1.2.5
> Host: localhost:8080
> Accept: */*
> Content-Length: 4778
> Content-Type: application/x-www-form-urlencoded
> Expect: 100-continue
> 
< HTTP/1.1 100 Continue
< Content-Length: 0
< Server: http-kit
< Date: Fri, 07 Mar 2014 20:06:53 GMT
} [data not shown]
< HTTP/1.1 202 Accepted
< Content-Type: text/plain
< Content-Length: 4778
< Server: http-kit
< Date: Fri, 07 Mar 2014 20:06:53 GMT