### PR TITLE
Support IE10/IE11 by responding to Pong frames

### DIFF
--- a/src/java/org/httpkit/server/WSDecoder.java
+++ b/src/java/org/httpkit/server/WSDecoder.java
@@ -155,6 +155,8 @@ public class WSDecoder {
                                     return new Frame.PingFrame(content);
                                 case OPCODE_CLOSE:
                                     return new Frame.CloseFrame(content);
+                                case OPCODE_PONG:
+                                    return new Frame.PingFrame(content);
                                 default:
                                     throw new ProtocolException("not impl for opcode: " + opcode);
                             }


### PR DESCRIPTION
IE10 and IE11sends pong frames and will disconnect if it doesn't receive a ping response: http://connect.microsoft.com/IE/feedback/details/804653/rfc6455-websocket-pong-frame

IE console:

```
SCRIPT12030: WebSocket Error: Network Error 12030, The connection with the server 
was terminated abnormally
```

Http-kit log:

```
Wed Mar 12 14:18:47 CET 2014 [server-loop] WARN - not impl for opcode: 10
```

This "fix" sends a ping response on pong request (which according to the spec is optional).

```
  A Pong frame MAY be sent unsolicited.  This serves as a
   unidirectional heartbeat.  A response to an unsolicited Pong frame is
   not expected.

Section 5.5.3 - http://datatracker.ietf.org/doc/rfc6455/?include_text=1
```
