### PR TITLE
Call on-close handlers on calling thread when threadpool is closed

### DIFF
--- a/src/java/org/httpkit/server/IHandler.java
+++ b/src/java/org/httpkit/server/IHandler.java
@@ -5,7 +5,7 @@ public interface IHandler {
 
     void handle(AsyncChannel channel, Frame frame);
 
-    public void clientClose(AsyncChannel channel, int status);
+    public void clientClose(AsyncChannel channel, int status, boolean currentThread);
 
     // close any resource with this handler
     void close(int timeoutMs);

--- a/test/java/org/httpkit/server/MultiThreadHttpServerTest.java
+++ b/test/java/org/httpkit/server/MultiThreadHttpServerTest.java
@@ -40,7 +40,7 @@ class MultiThreadHandler implements IHandler {
     public void handle(AsyncChannel channel, Frame.TextFrame frame) {
     }
 
-    public void clientClose(AsyncChannel channel, int status) {
+    public void clientClose(AsyncChannel channel, int status, boolean currentThread) {
     }
 }
 

--- a/test/java/org/httpkit/server/SingleThreadHttpServerTest.java
+++ b/test/java/org/httpkit/server/SingleThreadHttpServerTest.java
@@ -30,7 +30,7 @@ class SingleThreadHandler implements IHandler {
 
     }
 
-    public void clientClose(AsyncChannel channel, int status) {
+    public void clientClose(AsyncChannel channel, int status, boolean currentThread) {
     }
 }
 


### PR DESCRIPTION
Without this precaution, calling the returned stop function on
a server with pending handlers will raise execution rejected
exceptions since no slots are available in the shut-down pool.
