### PR TITLE
Default HttpClient callback thread pool is always one

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -85,7 +85,7 @@
 (def default-pool (let [max (.availableProcessors (Runtime/getRuntime))
                         queue (LinkedBlockingQueue.)
                         factory (PrefixThreadFactory. "client-worker-")]
-                    (ThreadPoolExecutor. 0 max 60 TimeUnit/SECONDS queue factory)))
+                    (ThreadPoolExecutor. max max 60 TimeUnit/SECONDS queue factory)))
 
 ;;;; Public API
 


### PR DESCRIPTION
Changing the default corePoolSize to the number of available
processors.

The default thead pool for running the http client async callbacks is
initialized with a coreSize of 0 and a unbounded queue. The
ThreadPoolExecutor creates threads just if all the coreSize threads are
busy and the queue is full. Given that the default queue is unbounded,
new threads are never created, hence the default-pool will never ever
have more than 1 thread to execute all the callbacks.

From the ThreadPoolExecutor doc (http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html):

"Using an unbounded queue (for example a LinkedBlockingQueue without a predefined capacity) will cause new tasks to wait in the queue when all corePoolSize threads are busy. Thus, no more than corePoolSize threads will ever be created"
