### PR TITLE
Fix formatting for history.md

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,19 +1,19 @@
 ## 2.1.18 (2014/4/18)
 HTTP Server:
-    1. #125 NPE on stop_server
-    2. #127 only trust the computed Content-Length heade
-    3. #134  pong frame expect a ping frame as response
+  1. #125 NPE on stop_server
+  2. #127 only trust the computed Content-Length heade
+  3. #134  pong frame expect a ping frame as response
 HTTP Client:
-    1. #127 only trust the computed Content-Length heade
-    2: #131 Fix the client handling of empty Reason-Phrase (Thanks Pyry Jahkola)
+  1. #127 only trust the computed Content-Length heade
+  2. #131 Fix the client handling of empty Reason-Phrase (Thanks Pyry Jahkola)
 
 ## 2.1.17 (2014/2/16)
 HTTP Server:
-    1. Allow max websocket message size configrable: max-ws option
-    2. #121 return the local-port of the server by meta
+  1. Allow max websocket message size configrable: max-ws option
+  2. #121 return the local-port of the server by meta
 HTTP Client:
-    1. #110 Stringify headers in the client. (thanks cursork)
-    2. #106 Fixed :multipart clobbering Authorization, User-Agent headers (thanks christianromney)
+  1. #110 Stringify headers in the client. (thanks cursork)
+  2. #106 Fixed :multipart clobbering Authorization, User-Agent headers (thanks christianromney)
 
 ## 2.1.16 (2014/1/3)
 HTTP Client:


### PR DESCRIPTION
Changed tabs before bullet lists to spaces. Makes markdown to understand them correctly.
