### PR TITLE
Remove Server header

### DIFF
--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -439,7 +439,6 @@ public class HttpUtils {
             headers.put(CL, Integer.toString(b.length));
             bodyBuffer = ByteBuffer.wrap(b);
         }
-        headers.put("Server", "http-kit");
         headers.put("Date", DateFormatter.getDate()); // rfc says the Date is needed
 
         DynamicBytes bytes = new DynamicBytes(196);


### PR DESCRIPTION
At best, it's an insecure default that requires a reverse proxy to remove.

http://cwe.mitre.org/data/definitions/200.html
