### PR TITLE
Fixing fragmented WebSocket messages

### DIFF
--- a/src/java/org/httpkit/server/WSDecoder.java
+++ b/src/java/org/httpkit/server/WSDecoder.java
@@ -168,7 +168,7 @@ public class WSDecoder {
                             payloadRead = 0;
                             if (opcode > 0)
                               fragmentedOpCode = opcode;
-                            opcode = OPCODE_CONT;
+                            opcode = -1;
                         }
                     }
                     break;


### PR DESCRIPTION
Frames with a payload length of 127 would cause WSDecoder to throw an
exception after going from PAYLOAD to FRAME_START as the opcode would
not match the conditions in FRAME_START. The fix was to set the variable 
"opcode" to -1 before returning to state FRAME_START. Another exception 
would be thrown on reading the final frame due to the first frame's 
opcode not being preserved. The fix was to add the variable 
"fragmentedOpCode" that would preserve the first frame's opcode. The 
changes should be in accordance with Section 5.4 of RFC 6455.

The ProtocolException in READ_8_LENGTH had a misleading statement. For
example, the max payload length can be greater than 4M. It now provides
a more informative message.