### PR TITLE
Transfer-Encoding is only supported in HTTP Version 1.1.

### DIFF
--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -114,7 +114,9 @@ public class AsyncChannel {
         if (close) { // normal response, Content-Length. Every http client understand it
             buffers = HttpEncode(status, headers, body);
         } else {
-            headers.put("Transfer-Encoding", "chunked"); // first chunk
+            if (request.version == HttpVersion.HTTP_1_1) {
+                headers.put("Transfer-Encoding", "chunked"); // first chunk
+            }
             ByteBuffer[] bb = HttpEncode(status, headers, body);
             if (body == null) {
                 buffers = bb;


### PR DESCRIPTION
Therefore the transfer-encoding header is only send in this version.