### PR TITLE
enable the use of keywords as callback funcs in requests,

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -190,7 +190,7 @@
            "See `request` for details.")
      ~'{:arglists '([url & [opts callback]] [url & [callback]])}
      ~'[url & [s1 s2]]
-     (if (or (instance? clojure.lang.MultiFn ~'s1) (fn? ~'s1))
+     (if (or (instance? clojure.lang.MultiFn ~'s1) (fn? ~'s1) (keyword? ~'s1))
        (request {:url ~'url :method ~(keyword method)} ~'s1)
        (request (merge ~'s1 {:url ~'url :method ~(keyword method)}) ~'s2))))
 


### PR DESCRIPTION
 so that this succinct line works:

  @(client/get url :status)

instead of awkwardly wrapping to #(:status %)