### PR TITLE
client: option to keep "unsafe" method on redirect

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -163,7 +163,8 @@
                                    :url (.toString ^URI (.resolve (URI. url) ^String
                                                                   (.get headers "location")))
                                    :response response
-                                   :method (if (#{301 302 303} status)
+                                   :method (if (and (not (:allow-unsafe-redirect-methods opts))
+                                                    (#{301 302 303} status))
                                              :get ;; change to :GET
                                              (:method opts))  ;; do not change
                                    :trace-redirects (conj (:trace-redirects opts) url))

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -293,6 +293,7 @@
     (is (= 200 (:status @(http/get url {:max-redirects 6}))))
     (is (= 302 (:status @(http/get url {:follow-redirects false}))))
     (is (= "get" (:body @(http/post url {:as :text})))) ; should switch to get method
+    (is (= "post" (:body @(http/post url {:as :text :allow-unsafe-redirect-methods true})))) ; should not change method
     (is (= "post" (:body @(http/post (str url "&code=307") {:as :text})))) ; should not change method
     ))
 


### PR DESCRIPTION
Currently the client changes the request method to GET when following a
301, 302, or 303 redirect. This adds an :allow-unsafe-redirect-methods
request option that can be used to override this behaviour.