### PR TITLE
add flash-policy-file request responder

### DIFF
--- a/src/java/org/httpkit/FlashPolicyFileRequestFoundExceiption.java
+++ b/src/java/org/httpkit/FlashPolicyFileRequestFoundExceiption.java
@@ -1,0 +1,10 @@
+package org.httpkit;
+
+public class FlashPolicyFileRequestFoundExceiption extends HTTPException {
+
+    private static final long serialVersionUID = 1L;
+
+    public FlashPolicyFileRequestFoundExceiption(String msg) {
+        super(msg);
+    }
+}

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -419,6 +419,37 @@ public class HttpUtils {
 
     public static final String CL = "Content-Length";
 
+    public static String FlashPolicyFileResponseString(List<String> allowAccessURIs) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<?xml version=\"1.0\"?>");
+        builder.append("<!DOCTYPE cross-domain-policy SYSTEM \"http://www.macromedia.com/xml/dtds/cross-domain-policy.dtd\">");
+        builder.append("<cross-domain-policy>");
+        for(String uriStr : allowAccessURIs) {
+            if("*".equals(uriStr)) {
+                builder.append("<allow-access-from domain=\"*\" to-ports=\"*\"/>");
+                continue;
+            }
+            URI uri = URI.create(uriStr);
+            builder.append(String.format("<allow-access-from domain=\"%s\" to-ports=\"%d\"/>", uri.getHost(), uri.getPort()));
+        }
+        if(allowAccessURIs.size()<1) {
+            builder.append("<allow-access-from domain=\"*\" to-ports=\"*\"/>");
+        }
+        builder.append("</cross-domain-policy>");
+        return builder.toString();
+    }
+
+    public static ByteBuffer FlashPolicyFileResponse(List<String> allowAccessURIs) {
+        ByteBuffer bodyBuffer;
+        try {
+            bodyBuffer = bodyBuffer(FlashPolicyFileResponseString(allowAccessURIs));
+        } catch (IOException e) {
+            byte[] b = e.getMessage().getBytes(ASCII);
+            bodyBuffer = ByteBuffer.wrap(b);
+        }
+        return bodyBuffer;
+    }
+
     public static ByteBuffer[] HttpEncode(int status, HeaderMap headers, Object body) {
         ByteBuffer bodyBuffer;
         try {

--- a/src/java/org/httpkit/LineReader.java
+++ b/src/java/org/httpkit/LineReader.java
@@ -39,7 +39,7 @@ public class LineReader {
             }
         }
         String line = null;
-        if (!more) {
+        if (!more || !buffer.hasRemaining()) {
             line = new String(lineBuffer, 0, lineBufferIdx);
             lineBufferIdx = 0;
         }

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -67,7 +67,7 @@ public class HttpDecoder {
     }
 
     public HttpRequest decode(ByteBuffer buffer) throws LineTooLargeException,
-            ProtocolException, RequestTooLargeException {
+            ProtocolException, RequestTooLargeException, FlashPolicyFileRequestFoundExceiption {
         String line;
         while (buffer.hasRemaining()) {
             switch (state) {
@@ -75,6 +75,9 @@ public class HttpDecoder {
                     return request;
                 case READ_INITIAL:
                     line = lineReader.readLine(buffer);
+                    if("<policy-file-request/>\0".equals(line)) {
+                        throw new FlashPolicyFileRequestFoundExceiption(line);
+                    }
                     if (line != null) {
                         createRequest(line);
                         state = State.READ_HEADER;

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -11,7 +11,7 @@
   param to wait existing requests to be finished, like (f :timeout 100).
 
   * See http://http-kit.org/migration.html for differences."
-  [handler {:keys [port thread ip max-body max-line worker-name-prefix queue-size max-ws]
+  [handler {:keys [port thread ip max-body max-line worker-name-prefix queue-size max-ws allow-access-uris]
             :or   {ip "0.0.0.0"  ; which ip (if has many ips) to bind
                    port 8090     ; which port listen incomming request
                    thread 4      ; http worker thread count
@@ -19,9 +19,12 @@
                    worker-name-prefix "worker-" ; woker thread name prefix
                    max-body 8388608             ; max http body: 8m
                    max-ws  4194304              ; max websocket message size: 4m
-                   max-line 4096}}]  ; max http inital line length: 4K
+                   max-line 4096
+                   allow-access-uris []}}]  ; max http inital line length: 4K
   (let [h (RingHandler. thread handler worker-name-prefix queue-size)
         s (HttpServer. ip port h max-body max-line max-ws)]
+    (doseq [uri allow-access-uris]
+      (.addAllowAccessUri s uri))
     (.start s)
     (with-meta (fn stop-server [& {:keys [timeout] :or {timeout 100}}]
                  ;; graceful shutdown:


### PR DESCRIPTION
I found as if the library does not support the passage of flash-policy-file to supply WebSocket browser does not support flash to a compatible WebSocket through the API, so I modify the code to support flash-policy-file responder. user can add :allow-access-uris ["http://example.com:843"] in run-server params