### PR TITLE
Changed run-server function to return server thread in meta

### DIFF
--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -29,7 +29,8 @@
                  ;; 2. wait for existing requests to finish
                  ;; 3. close the server
                  (.stop s timeout))
-      {:local-port (.getPort s)})))
+      {:local-port (.getPort s)
+       :server s})))
 
 ;;;; Asynchronous extension
 


### PR DESCRIPTION
The returned server thread could be used.