### PR TITLE
More accurate timeout handling

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -361,8 +361,13 @@ public final class HttpClient implements Runnable {
     public void run() {
         while (running) {
             try {
+                Request first = requests.peek();
+                long timeout = 2000;
+                if (first != null) {
+                    timeout = Math.max(first.toTimeout(currentTimeMillis()), 200L);
+                }
+                int select = selector.select(timeout);
                 long now = currentTimeMillis();
-                int select = selector.select(2000);
                 if (select > 0) {
                     Set<SelectionKey> selectedKeys = selector.selectedKeys();
                     Iterator<SelectionKey> ite = selectedKeys.iterator();

--- a/src/java/org/httpkit/client/Request.java
+++ b/src/java/org/httpkit/client/Request.java
@@ -55,6 +55,10 @@ public class Request implements Comparable<Request> {
         return timeoutTs < now;
     }
 
+    public long toTimeout(long now) {
+        return Math.max(timeoutTs - now, 0L);
+    }
+
     public void finish(Throwable t) {
         clients.remove(this);
         if (isDone)


### PR DESCRIPTION
With the current implementation, the actual connect timeout can be up to 2 seconds greater than the passed-in connection timeout; the patch tries to address this by using the time remaining for the the first queued request to expire as the actual timeout.