### PR TITLE
LinkedRunnable.run: don't consume stack unnecessarily

### DIFF
--- a/src/java/org/httpkit/server/RingHandler.java
+++ b/src/java/org/httpkit/server/RingHandler.java
@@ -118,8 +118,12 @@ class LinkingRunnable implements Runnable {
 
     public void run() {
         impl.run();
-        if (!next.compareAndSet(null, this)) { // has more job to run
-            next.get().run();
+
+        // Run all jobs in this chain without consuming extra call stack
+        LinkingRunnable r = this;
+        while (!r.next.compareAndSet(null, r)) {
+            r = r.next.get();
+            r.impl.run();
         }
     }
 }


### PR DESCRIPTION
Sending lots of small messages at a high rate to an http-kit websocket will sometimes create a chain of LinkedRunnable's long enough to cause a stack overflow on this line:

https://github.com/http-kit/http-kit/blob/73f82165c73d2a0599e610db8cb7a50de48d31cd/src/java/org/httpkit/server/RingHandler.java#L122

This pull request implements a loop to follow the chain in a single stack frame, avoiding the stack overflow.