### PR TITLE
Catch Throwable when delivering response

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -149,7 +149,7 @@
   (let [{:keys [url method headers body sslengine]} (coerce-req opts)
         deliver-resp #(deliver response ;; deliver the result
                                (try ((or callback identity) %1)
-                                    (catch Exception e
+                                    (catch Throwable e
                                       ;; dump stacktrace to stderr
                                       (HttpUtils/printError (str method " " url "'s callback") e)
                                       ;; return the error

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -120,7 +120,16 @@
           (doseq [r requests]
             (is (= 200 (:status @r))))))
       (doseq [_ (range 0 200)]
-        (is (= 200 (:status @(http/get url))))))))
+        (is (= 200 (:status @(http/get url))))))
+
+    (testing "callback exception handling"
+      (let [{error :error} @(http/get (str host "/get")
+                                      (fn [_] (throw (Exception. "Exception"))))]
+        (is (= "Exception" (.getMessage error))))
+
+      (let [{error :error} @(http/get (str host "/get")
+                                      (fn [_] (throw (Throwable. "Throwable"))))]
+        (is (= "Throwable" (.getMessage error)))))))
 
 
 (deftest test-unicode-encoding


### PR DESCRIPTION
The `deliver-resp` helper function in `org.httpkit.client/request` catches Exception, but not Throwable. Any code in the callback that throws Throwable rather than Exception prevents the client thread from ever returning (so far as I can tell). That is unfortunate, because Clojure's `assert`, and `:pre` and `:post` conditions all throw Throwable rather than Exception, leading to some very hard to troubleshoot failures.

I believe this might be the problem behind these issues:

* https://github.com/http-kit/http-kit/issues/73
* https://github.com/http-kit/http-kit/issues/118
* https://github.com/http-kit/http-kit/issues/194

If not, they at least appear to describe behavior in http-kit similar to what made me look into this. 