### PR TITLE
Add Proxy Protocol support

### DIFF
--- a/src/java/org/httpkit/server/HttpAtta.java
+++ b/src/java/org/httpkit/server/HttpAtta.java
@@ -2,8 +2,8 @@ package org.httpkit.server;
 
 public class HttpAtta extends ServerAtta {
 
-    public HttpAtta(int maxBody, int maxLine) {
-        decoder = new HttpDecoder(maxBody, maxLine);
+    public HttpAtta(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption) {
+        decoder = new HttpDecoder(maxBody, maxLine, proxyProtocolOption);
     }
 
     public final HttpDecoder decoder;

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -73,7 +73,7 @@ public class HttpDecoder {
 
     private boolean parseProxyLine(String line) throws ProtocolException {
         // PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n
-        if (line.startsWith("PROXY ")) {
+        if (!line.startsWith("PROXY ")) {
             return false;
         }
 

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -31,7 +31,7 @@ public class HttpDecoder {
      * Pattern for matching numbers 0 to 255.  We use this in the IPV4 address pattern to prevent invalid sequences
      * from be parsed by InetAddress.getByName and thus being treated as a name instead of an address.
      */
-    private static final String IPV4SEG = "(?:0|1\\d{0,2}|2(?:[0-4]\\d+|5[0-5]?|[6-9])?|[3-9]\\d?)";
+    private static final String IPV4SEG = "(?:0|1\\d{0,2}|2(?:[0-4]\\d*|5[0-5]?|[6-9])?|[3-9]\\d?)";
     private static final String IPV4ADDR = IPV4SEG + "(?:\\." + IPV4SEG + "){3}";
     /**
      * Pattern for a port number.  We are not as strict in our pattern matching as we are with ipv4 address

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -250,6 +250,12 @@ public class HttpDecoder {
 
     private void readHeaders(ByteBuffer buffer) throws LineTooLargeException,
             RequestTooLargeException, ProtocolException {
+        if (proxyProtocolOption == ProxyProtocolOption.OPTIONAL
+            || proxyProtocolOption == ProxyProtocolOption.ENABLED) {
+            headers.put("x-forwarded-for", xForwardedFor);
+            headers.put("x-forwarded-proto", xForwardedProto);
+            headers.put("x-forwarded-port", xForwardedPort);
+        }
         String line = lineReader.readLine(buffer);
         while (line != null && !line.isEmpty()) {
             HttpUtils.splitAndAddHeader(line, headers);

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -1,11 +1,21 @@
 package org.httpkit.server;
 
-import org.httpkit.*;
-
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.httpkit.HttpMethod;
+import org.httpkit.HttpUtils;
+import org.httpkit.HttpVersion;
+import org.httpkit.LineReader;
+import org.httpkit.LineTooLargeException;
+import org.httpkit.ProtocolException;
+import org.httpkit.RequestTooLargeException;
 
 import static org.httpkit.HttpUtils.*;
 import static org.httpkit.HttpVersion.HTTP_1_0;
@@ -14,13 +24,36 @@ import static org.httpkit.HttpVersion.HTTP_1_1;
 public class HttpDecoder {
 
     public enum State {
-        ALL_READ, READ_INITIAL, READ_HEADER, READ_FIXED_LENGTH_CONTENT, READ_CHUNK_SIZE, READ_CHUNKED_CONTENT, READ_CHUNK_FOOTER, READ_CHUNK_DELIMITER,
+        ALL_READ, CONNECTION_OPEN, READ_INITIAL, READ_HEADER, READ_FIXED_LENGTH_CONTENT, READ_CHUNK_SIZE, READ_CHUNKED_CONTENT, READ_CHUNK_FOOTER, READ_CHUNK_DELIMITER,
     }
 
-    private State state = State.READ_INITIAL;
+    /**
+     * Pattern for matching numbers 0 to 255.  We use this in the IPV4 address pattern to prevent invalid sequences
+     * from be parsed by InetAddress.getByName and thus being treated as a name instead of an address.
+     */
+    private static final String IPV4SEG = "(?:0|1\\d{0,2}|2(?:[0-4]\\d+|5[0-5]?|[6-9])?|[3-9]\\d?)";
+    private static final String IPV4ADDR = IPV4SEG + "(?:\\." + IPV4SEG + "){3}";
+    /**
+     * Pattern for a port number.  We are not as strict in our pattern matching as we are with ipv4 address
+     * and instead rely upon Integer.parseInt and a range check.  Port 0 is invalid, so we disallow that here.
+     */
+    private static final String PORT = "[1-9]\\d{0,4}";
+    /**
+     * The PROXY protocol header is quite strict in what it allows, specifying for example that only
+     * a single space character (\x20) is allowed between components.
+     */
+    private static final Pattern PROXY_PATTERN = Pattern.compile(
+        "PROXY\\x20TCP4\\x20(" + IPV4ADDR + ")\\x20(" + IPV4ADDR +")\\x20(" + PORT + ")\\x20(" + PORT + ")"
+    );
+
+    private State state;
+    private ProxyProtocolOption proxyProtocolOption;
     private int readRemaining = 0; // bytes need read
     private int readCount = 0; // already read bytes count
 
+    private String xForwardedFor;
+    private String xForwardedProto;
+    private int xForwardedPort;
     HttpRequest request; // package visible
     private Map<String, Object> headers = new TreeMap<String, Object>();
     byte[] content;
@@ -28,9 +61,53 @@ public class HttpDecoder {
     private final int maxBody;
     private final LineReader lineReader;
 
-    public HttpDecoder(int maxBody, int maxLine) {
+    public HttpDecoder(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption) {
         this.maxBody = maxBody;
         this.lineReader = new LineReader(maxLine);
+        this.proxyProtocolOption = (proxyProtocolOption == null)
+            ? ProxyProtocolOption.DISABLED : proxyProtocolOption;
+
+        this.state = (proxyProtocolOption == ProxyProtocolOption.DISABLED)
+            ? State.READ_INITIAL : State.CONNECTION_OPEN;
+    }
+
+    private boolean parseProxyLine(String line) throws ProtocolException {
+        // PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n
+        if (line.startsWith("PROXY ")) {
+            return false;
+        }
+
+        final Matcher m = PROXY_PATTERN.matcher(line);
+        if (!m.matches()) {
+            throw new ProtocolException("Unsupported or malformed proxy header: "+line);
+        }
+
+        try {
+            final InetAddress clientAddr = InetAddress.getByName(m.group(1));
+            final InetAddress proxyAddr = InetAddress.getByName(m.group(2));
+
+            final int clientPort = Integer.parseInt(m.group(3), 10);
+            final int proxyPort = Integer.parseInt(m.group(4), 10);
+
+            if (((clientPort | proxyPort) & ~0xffff) != 0) {
+                throw new ProtocolException("Invalid port number: "+line);
+            }
+
+            xForwardedFor = clientAddr.getHostAddress();
+            if (proxyPort == 80) {
+                xForwardedProto = "http";
+            } else if (proxyPort == 443) {
+                xForwardedProto = "https";
+            }
+            xForwardedPort = proxyPort;
+
+            return true;
+
+        } catch (NumberFormatException ex) {
+            throw new ProtocolException("Malformed port in: "+line);
+        } catch (UnknownHostException ex) {
+            throw new ProtocolException("Malformed address in: "+line);
+        }
     }
 
     private void createRequest(String sb) throws ProtocolException {
@@ -79,6 +156,25 @@ public class HttpDecoder {
             switch (state) {
                 case ALL_READ:
                     return request;
+                case CONNECTION_OPEN:
+                    line = lineReader.readLine(buffer);
+                    if (line != null) {
+                        // parseProxyLines returns true if the line parsed
+                        // false if it was not a PROXY line
+                        // or throws ProtocolException, if the PROXY line is malformed or unsupported.
+                        if (parseProxyLine(line)) {
+                            // valid proxy header
+                            state = State.READ_INITIAL;
+                        } else if (proxyProtocolOption == ProxyProtocolOption.OPTIONAL) {
+                            // did not parse as a proxy header, try to create a request from it
+                            // as the READ_INITIAL state would.
+                            createRequest(line);
+                            state = State.READ_HEADER;
+                        } else {
+                            throw new ProtocolException("Expected PROXY header, got: "+line);
+                        }
+                    }
+                    break;
                 case READ_INITIAL:
                     line = lineReader.readLine(buffer);
                     if (line != null) {

--- a/src/java/org/httpkit/server/ProxyProtocolOption.java
+++ b/src/java/org/httpkit/server/ProxyProtocolOption.java
@@ -1,0 +1,10 @@
+package org.httpkit.server;
+
+/**
+ * Created by jeffi on 7/16/15.
+ */
+public enum ProxyProtocolOption {
+    DISABLED,
+    ENABLED,
+    OPTIONAL
+}

--- a/test/java/org/httpkit/server/MultiThreadHttpServerTest.java
+++ b/test/java/org/httpkit/server/MultiThreadHttpServerTest.java
@@ -47,7 +47,7 @@ class MultiThreadHandler implements IHandler {
 public class MultiThreadHttpServerTest {
     public static void main(String[] args) throws IOException {
         HttpServer server = new HttpServer("0.0.0.0", 9091, new MultiThreadHandler(), 20480,
-                2048, 1024 * 1024 * 4);
+                2048, 1024 * 1024 * 4, ProxyProtocolOption.DISABLED);
         server.start();
         System.out.println("Server started on :9091");
     }

--- a/test/java/org/httpkit/server/SingleThreadHttpServerTest.java
+++ b/test/java/org/httpkit/server/SingleThreadHttpServerTest.java
@@ -39,7 +39,7 @@ public class SingleThreadHttpServerTest {
         // concurrency 1024, 2000000 request, time: 16545ms; 120882.44 req/s;
         // receive: 93M data; 5.62 M/s
         HttpServer server = new HttpServer("0.0.0.0", 9091, new SingleThreadHandler(), 20480,
-                2048, 1024 * 1024 * 4);
+                2048, 1024 * 1024 * 4, ProxyProtocolOption.DISABLED);
         server.start();
 
         // 2012/11/28


### PR DESCRIPTION
Add proxy protocol support. 

Some background about Proxy Protocol:

http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt

Since AWS ELB does not support WebSocket using HTTP protocol. The work around is to use TCP with PROXY Protocol. 

This patch will add PROXY Protocol support. 