### PR TITLE
HTTP client: keep form params in multipart requests

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -71,8 +71,9 @@
             ;; :body ring body: null, String, seq, InputStream, File, ByteBuffer
             :body      (if form-params (query-string form-params) body))]
     (if multipart
-      (let [entities (map (fn [{:keys [name content filename]}]
-                            (MultipartEntity. name content filename)) multipart)
+      (let [entities (into (map (fn [{:keys [name content filename]}]
+                             (MultipartEntity. name content filename)) multipart)
+                           (map (fn [[k v]] (MultipartEntity. k v nil)) form-params))
             boundary (MultipartEntity/genBoundary entities)]
         (-> r
             (assoc-in [:headers "Content-Type"]


### PR DESCRIPTION
Currently, if a multipart request has both form params and files, the former are lost when coercing the request. This PR fixes the issue.