### PR TITLE
Correctly reset fragmentedOpCode on WS frame completion.

### DIFF
--- a/src/java/org/httpkit/server/WSDecoder.java
+++ b/src/java/org/httpkit/server/WSDecoder.java
@@ -149,6 +149,7 @@ public class WSDecoder {
                         if (finalFlag) {
                             if (fragmentedOpCode > 0)
                               opcode = fragmentedOpCode;
+                            fragmentedOpCode = -1;
                             switch (opcode) {
                                 case OPCODE_TEXT:
                                     return new Frame.TextFrame(content);


### PR DESCRIPTION
When sending frames of different types (opcodes) over websockets to the httpkit server, the type of frames is incorrectly set after fragmentation occurs. This is because `fragmentedOpCode` is never reset in `WSDecoder.java`. This pull request fixes the bug.

To reproduce the problem:

* Send a text frame to the server
* Send a fragmented binary frame to the server
* Send a text frame to the server

Notice that the final text frame is delivered as a binary frame. This obviously shouldn't happen.

I would have liked to add a test to cover this case, but I'm afraid I couldn't work out how to force the `org.httpkit.ws.WebSocketClient` to fragment a binary frame in the necessary way. I'd be happy to add a test if someone could point me in the right direction.