### PR TITLE
Remind the selector to wake up.

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -253,9 +253,11 @@ public class HttpServer implements Runnable {
                         selector.wakeup();
                     } else if (!atta.isKeepAlive()) {
                         pending.add(new PendingKey(key, CLOSE_NORMAL));
+                        selector.wakeup();
                     }
                 } catch (IOException e) {
                     pending.add(new PendingKey(key, CLOSE_AWAY));
+                    selector.wakeup();
                 }
             } else {
                 // If has pending write, order should be maintained. (WebSocket)
@@ -270,7 +272,8 @@ public class HttpServer implements Runnable {
         while (true) {
             try {
                 PendingKey k;
-                while ((k = pending.poll()) != null) {
+                while (!pending.isEmpty()) {
+                    k = pending.poll();
                     if (k.Op == PendingKey.OP_WRITE) {
                         if (k.key.isValid()) {
                             k.key.interestOps(OP_WRITE);


### PR DESCRIPTION
This commit adds `selector.wakeup()` calls after adding new PendingKeys to the
ConcurrentLinkedList; if we don't do this the main thread blocks on the
`selector.select` call and eventually times out.

This commit also cleans up the polling logic to read a little cleaner, I think.

Resolves #148 

cc @ptaoussanis 