### PR TITLE
Reset decoder after starting the close handshake for the websocket se…

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -159,6 +159,7 @@ public class HttpServer implements Runnable {
                     handler.clientClose(atta.channel, ((CloseFrame) frame).getStatus());
                     // close the TCP connection after sent
                     atta.keepalive = false;
+                    atta.decoder.reset();
                     tryWrite(key, WsEncode(WSDecoder.OPCODE_CLOSE, frame.data));
                 }
             } while (buffer.hasRemaining()); // consume all


### PR DESCRIPTION
…rver

In org.http.server.HttpServer.decodeWs(...), when we receive a CloseFrame, we
don't reset the decoder. This eventually causes the server to run out of memory
as the server just sends CLOSE infinitely.

This commit adds a call to reset the decoder so that we don't get stuck in the
infinite close loop.

Resolves #227