### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 *jar
 .classpath
 .lein-deps-sum

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -59,20 +59,20 @@
 (defn- coerce-req
   [{:keys [url method body insecure? query-params form-params multipart] :as req}]
   (let [r (assoc req
-            :url (if query-params
-                   (if (neg? (.indexOf ^String url (int \?)))
-                     (str url "?" (query-string query-params))
-                     (str url "&" (query-string query-params)))
-                   url)
-            :sslengine (or (:sslengine req)
-                           (when (:insecure? req) (SslContextFactory/trustAnybody)))
-            :method    (HttpMethod/fromKeyword (or method :get))
-            :headers   (prepare-request-headers req)
+                 :url (if query-params
+                        (if (neg? (.indexOf ^String url (int \?)))
+                          (str url "?" (query-string query-params))
+                          (str url "&" (query-string query-params)))
+                        url)
+                 :sslengine (or (:sslengine req)
+                                (when (:insecure? req) (SslContextFactory/trustAnybody)))
+                 :method    (HttpMethod/fromKeyword (or method :get))
+                 :headers   (prepare-request-headers req)
             ;; :body ring body: null, String, seq, InputStream, File, ByteBuffer
-            :body      (if form-params (query-string form-params) body))]
+                 :body      (if form-params (query-string form-params) body))]
     (if multipart
       (let [entities (into (map (fn [{:keys [name content filename]}]
-                             (MultipartEntity. name content filename)) multipart)
+                                  (MultipartEntity. name content filename)) multipart)
                            (map (fn [[k v]] (MultipartEntity. k v nil)) form-params))
             boundary (MultipartEntity/genBoundary entities)]
         (-> r
@@ -164,14 +164,14 @@
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
                         (request (assoc opts ; follow 301 and 302 redirect
-                                   :url (.toString ^URI (.resolve (URI. url) ^String
-                                                                  (.get headers "location")))
-                                   :response response
-                                   :method (if (and (not allow-unsafe-redirect-methods)
-                                                    (#{301 302 303} status))
-                                             :get ;; change to :GET
-                                             (:method opts))  ;; do not change
-                                   :trace-redirects (conj trace-redirects url))
+                                        :url (.toString ^URI (.resolve (URI. url) ^String
+                                                                       (.get headers "location")))
+                                        :response response
+                                        :method (if (and (not allow-unsafe-redirect-methods)
+                                                         (#{301 302 303} status))
+                                                  :get ;; change to :GET
+                                                  (:method opts))  ;; do not change
+                                        :trace-redirects (conj trace-redirects url))
                                  callback)
                         (deliver-resp {:opts (dissoc opts :response)
                                        :error (Exception. (str "too many redirects: "

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -99,9 +99,9 @@
 (defn request
   "Issues an async HTTP request and returns a promise object to which the value
   of `(callback {:opts _ :status _ :headers _ :body _})` or
-     `(callback {:opts _ :error _})` will be delivered. 
-  The latter will be delivered on client errors only, not on http errors which will be 
-  contained in the :status of the first. 
+     `(callback {:opts _ :error _})` will be delivered.
+  The latter will be delivered on client errors only, not on http errors which will be
+  contained in the :status of the first.
 
   When unspecified, `callback` is the identity
 
@@ -164,7 +164,7 @@
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
                         (request (assoc opts ; follow 301 and 302 redirect
-                                        :url (.toString ^URI (.resolve (URI. url) ^String
+                                        :url (str (.resolve (URI. url) ^String
                                                                        (.get headers "location")))
                                         :response response
                                         :method (if (and (not allow-unsafe-redirect-methods)

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -50,8 +50,8 @@
   (GET "/p" [] (fn [req] (pr-str (:params req))))
   (ANY "/params" [] (fn [req] (-> req :params :param1)))
   (PUT "/body" [] (fn [req] {:body (:body req)
-                            :status 200
-                            :headers {"content-type" "text/plain"}}))
+                             :status 200
+                             :headers {"content-type" "text/plain"}}))
   (GET "/test-header" [] (fn [{:keys [headers]}] (str (get headers "test-header")))))
 
 (use-fixtures :once
@@ -124,13 +124,12 @@
 
     (testing "callback exception handling"
       (let [{^Exception error :error} @(http/get (str host "/get")
-                                      (fn [_] (throw (Exception. "Exception"))))]
+                                                 (fn [_] (throw (Exception. "Exception"))))]
         (is (= "Exception" (.getMessage error))))
 
       (let [{^Throwable error :error} @(http/get (str host "/get")
-                                      (fn [_] (throw (Throwable. "Throwable"))))]
+                                                 (fn [_] (throw (Throwable. "Throwable"))))]
         (is (= "Throwable" (.getMessage error)))))))
-
 
 (deftest test-unicode-encoding
   (let [u "高性能HTTPServer和Client"
@@ -242,7 +241,7 @@
                (java.io.FileInputStream. file) ; inputstream
                [(subs const-string 0 100) (subs const-string 100 length)] ; seqable
                (ByteBuffer/wrap (.getBytes (subs const-string 0 length))) ; byteBuffer
-               ]]
+]]
     (doseq [body bodys]
       (is (= length (count (:body @(http/put "http://127.0.0.1:4347/body"
                                              {:body body}))))))))
@@ -304,13 +303,12 @@
     (is (= "get" (:body @(http/post url {:as :text})))) ; should switch to get method
     (is (= "post" (:body @(http/post url {:as :text :allow-unsafe-redirect-methods true})))) ; should not change method
     (is (= "post" (:body @(http/post (str url "&code=307") {:as :text})))) ; should not change method
-    ))
+))
 
 (deftest test-multipart
   (is (= 200 (:status @(http/post "http://localhost:4347/multipart"
                                   {:multipart [{:name "comment" :content "httpkit's project.clj"}
                                                {:name "file" :content (clojure.java.io/file "project.clj") :filename "project.clj"}]})))))
-
 
 (deftest test-coerce-req
   "Headers should be the same regardless of multipart"
@@ -319,7 +317,6 @@
     (is (= (keys (:headers (coerce-req request)))
            (remove #(= % "Content-Type")
                    (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}])))))))))
-
 
 (deftest test-header-multiple-values
   (let [resp @(http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}})
@@ -335,8 +332,8 @@
                            ['(0) "0"]
                            ['("a" "b") "a,b"]]]
     (let [received (:body @(http/get "http://localhost:4347/test-header"
-                             {:headers {"test-header" sent}}))]
-        (is (= received expected)))))
+                                     {:headers {"test-header" sent}}))]
+      (is (= received expected)))))
 
 (defn- utf8 [^String s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
 
@@ -390,9 +387,7 @@
     ;; One header.
     HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-     [:headers {"content-length" "0"}]]
-
-    ))
+     [:headers {"content-length" "0"}]]))
 
 (deftest test-decode-body
   (are [method resp events] (= (decode method (utf8 resp)) events)
@@ -407,23 +402,21 @@
      [:headers {"content-length" "1"}]]
 
      ;; One byte.
-     HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n."
-     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-      [:headers {"content-length" "1"}]
-      [:body [46]]]
+    HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n."
+    [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
+     [:headers {"content-length" "1"}]
+     [:body [46]]]
 
      ;; One byte. The rest is ignored.
-     HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n..."
-     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-      [:headers {"content-length" "1"}]
-      [:body [46]]]
+    HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n..."
+    [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
+     [:headers {"content-length" "1"}]
+     [:body [46]]]
 
     ;; The body is omitted for HEAD requests.
     HttpMethod/HEAD "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n..."
     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-     [:headers {"content-length" "3"}]]
-
-    ))
+     [:headers {"content-length" "3"}]]))
 
 ;; @(http/get "http://127.0.0.1:4348" {:headers {"Connection" "Close"}})
 

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -233,7 +233,7 @@
                                 identity)
                  :headers :x-method read-string)))))
 
-(deftest test-string-file-inputstream-body []
+(deftest test-string-file-inputstream-body
   (let [length (+ (rand-int (* 1024 1024 5)) 100)
         file (gen-tempfile length ".txt")
         bodys [(subs const-string 0 length)    ;string
@@ -311,12 +311,12 @@
                                                {:name "file" :content (clojure.java.io/file "project.clj") :filename "project.clj"}]})))))
 
 (deftest test-coerce-req
-  "Headers should be the same regardless of multipart"
-  (let [coerce-req #'org.httpkit.client/coerce-req
-        request {:basic-auth ["user" "pass"]}]
-    (is (= (keys (:headers (coerce-req request)))
-           (remove #(= % "Content-Type")
-                   (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}])))))))))
+  (testing "Headers should be the same regardless of multipart"
+    (let [coerce-req #'org.httpkit.client/coerce-req
+          request {:basic-auth ["user" "pass"]}]
+      (is (= (keys (:headers (coerce-req request)))
+             (remove #(= % "Content-Type")
+                     (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}]))))))))))
 
 (deftest test-header-multiple-values
   (let [resp @(http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}})

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -123,11 +123,11 @@
         (is (= 200 (:status @(http/get url))))))
 
     (testing "callback exception handling"
-      (let [{error :error} @(http/get (str host "/get")
+      (let [{^Exception error :error} @(http/get (str host "/get")
                                       (fn [_] (throw (Exception. "Exception"))))]
         (is (= "Exception" (.getMessage error))))
 
-      (let [{error :error} @(http/get (str host "/get")
+      (let [{^Throwable error :error} @(http/get (str host "/get")
                                       (fn [_] (throw (Throwable. "Throwable"))))]
         (is (= "Throwable" (.getMessage error)))))))
 
@@ -266,7 +266,7 @@
       (is (string? body)))
     (let [body (:body @(http/get url {:as :stream}))]
       (is (instance? java.io.InputStream body)))
-    (let [body (:body @(http/get url {:as :byte-array}))]
+    (let [^bytes body (:body @(http/get url {:as :byte-array}))]
       (is (= 1024 (alength body))))))
 
 (deftest test-https
@@ -274,7 +274,7 @@
     (doseq [i (range 0 2)]
       (doseq [length (repeatedly 40 (partial rand-int (* 4 1024 1024)))]
         (let [{:keys [body error status]} @(http/get (get-url length) {:insecure? true})]
-          (if error (.printStackTrace error))
+          (if error (.printStackTrace ^Throwable error))
           (is (= length (count body)))))
       (doseq [length (repeatedly 40 (partial rand-int (* 4 1024 1024)))]
         (is (= length (-> @(http/get (get-url length)
@@ -338,7 +338,7 @@
                              {:headers {"test-header" sent}}))]
         (is (= received expected)))))
 
-(defn- utf8 [s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
+(defn- utf8 [^String s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
 
 (defn- decode
   [method buffer]

--- a/test/org/httpkit/proxy_test.clj
+++ b/test/org/httpkit/proxy_test.clj
@@ -10,7 +10,7 @@
    :timeout 30000 ;ms
    :method (:request-method req)
    :headers (assoc (:headers req)
-              "X-Forwarded-For" (:remote-addr req))
+                   "X-Forwarded-For" (:remote-addr req))
    :body (:body req)})
 
 (defn handler [req]

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -90,7 +90,7 @@
                           :body "canceled"}))))))
 
 (defn streaming-demo [request]
-  (let [time (Integer/valueOf (or (-> request :params :i) 200))]
+  (let [time (Integer/valueOf (or ^String (-> request :params :i) 200))]
     (with-channel request channel
       (on-close channel (fn [status]
                           (println channel "closed" status)))

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -187,12 +187,12 @@
 
 (deftest test-body-file
   (doseq [length (range 1 (* 1024 1024 8) 1439987)]
-    (let [resp (http/get "http://localhost:4347/file?l=" length)]
+    (let [resp (http/get (str "http://localhost:4347/file?l=" length))]
       (is (= (:status resp) 200))
       (is (= (get-in resp [:headers "content-type"]) "text/plain"))
       (is (= length (count (:body resp)))))))
 
-(deftest test-body-file
+(deftest test-other-body-file
   (let [resp (http/get "http://localhost:4347/file")]
     (is (= (:status resp) 200))
     (is (= (get-in resp [:headers "content-type"]) "text/plain"))

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -30,10 +30,10 @@
   (let [count (or (-> req :params :count to-int) 20)]
     {:status 200
      :headers (assoc
-                  (into {} (map (fn [idx]
-                                  [(str "key-" idx) (str "value-" idx)])
-                                (range 0 (inc count))))
-                "x-header-1" ["abc" "def"])}))
+               (into {} (map (fn [idx]
+                               [(str "key-" idx) (str "value-" idx)])
+                             (range 0 (inc count))))
+               "x-header-1" ["abc" "def"])}))
 
 (defn multipart-handler [req]
   (let [{:keys [title file]} (:params req)]
@@ -66,7 +66,7 @@
                          {:body p})
                false))        ;; do not close
       (send! channel "" true) ;; same as (close channel)
-      )))
+)))
 
 (defn slow-server-handler [req]
   (with-channel req channel
@@ -143,7 +143,6 @@
                       (let [server (run-server
                                     (site test-routes) {:port 4347})]
                         (try (f) (finally (server))))))
-
 
 (deftest test-ring-spec
   (let [req (-> (http/get "http://localhost:4347/spec?c=d"

--- a/test/org/httpkit/test_util.clj
+++ b/test/org/httpkit/test_util.clj
@@ -21,7 +21,7 @@
          (.write w ^bytes (.getBytes (subs const-string 0 size))))
        tmp)))
 
-(defn to-int [int-str] (Integer/valueOf int-str))
+(defn to-int [^String int-str] (Integer/valueOf int-str))
 
 (def channel-closed (atom false))
 

--- a/test/org/httpkit/test_util.clj
+++ b/test/org/httpkit/test_util.clj
@@ -14,12 +14,12 @@
 (defn ^File gen-tempfile
   "generate a tempfile, the file will be deleted before jvm shutdown"
   ([size extension]
-     (let [tmp (doto
-                   (File/createTempFile "tmp_" extension)
-                 (.deleteOnExit))]
-       (with-open [w (FileOutputStream. tmp)]
-         (.write w ^bytes (.getBytes (subs const-string 0 size))))
-       tmp)))
+   (let [tmp (doto
+              (File/createTempFile "tmp_" extension)
+               (.deleteOnExit))]
+     (with-open [w (FileOutputStream. tmp)]
+       (.write w ^bytes (.getBytes (subs const-string 0 size))))
+     tmp)))
 
 (defn to-int [^String int-str] (Integer/valueOf int-str))
 

--- a/test/org/httpkit/utils_test.clj
+++ b/test/org/httpkit/utils_test.clj
@@ -9,7 +9,7 @@
 
 (defn charset [name] (Charset/forName name))
 
-(defn detect-charset [headers body]
+(defn detect-charset [headers ^String body]
   (let [b (doto (DynamicBytes. 128)
             (.append body))]
     (HttpUtils/detectCharset headers b)))

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -152,9 +152,9 @@
     (dotimes [_ 5]
       (let [length (min 1024 (rand-int 10024))
             data (byte-array length (take length (repeatedly #(byte (rand-int 126)))))
-            sorted-data (doto (aclone data) (java.util.Arrays/sort))]
+            ^bytes sorted-data (doto (aclone data) (java.util.Arrays/sort))]
         (.sendBinaryData client data)
-        (let [output (.getMessage client)]
+        (let [^bytes output (.getMessage client)]
           (is (java.util.Arrays/equals sorted-data output)))))
     (.close client)))
 

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -205,10 +205,10 @@
                                   (deliver latch true))
                           :close (fn [con status]
                                    ;; (println "close:" con status)
-                                   )
+)
                           :open (fn [con]
                                   ;; (println "opened:" con)
-                                  ))]
+))]
       ;; (h/send ws :byte (byte-array 10)) not implemented yet
       (let [msg "testing12"]
         (h/send ws :text msg)

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -118,8 +118,8 @@
                             "\nreceive:\n" r))
               (is false))))
         (let [d (subs const-string 0 120)]
-          (= d (.ping client d))
-          (= d (.pong client d)))))
+          (is (= d (.ping client d)))
+          (is (= d (.pong client d))))))
     (.close client)))
 
 (deftest test-sent-message-in-body      ; issue #14


### PR DESCRIPTION
This PR encompasses a number of disparate cleanup efforts, largely oriented around the test code. 

Some aspects of this:
 * Type hints to reduce the reflection warnings
 * Fixing indentation
 * Minor idiomatic fixes
 * Re-enabling clobbered tests and cases where assertions should have existed but didn't