### PR TITLE
[client] #209 plus some related client fixes

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -345,6 +345,8 @@ public final class HttpClient implements Runnable {
             }
             try {
                 SocketChannel ch = SocketChannel.open();
+                ch.setOption(StandardSocketOptions.SO_KEEPALIVE, Boolean.TRUE);
+                ch.setOption(StandardSocketOptions.TCP_NODELAY, Boolean.TRUE);
                 ch.configureBlocking(false);
                 boolean connected = ch.connect(job.addr);
                 job.isConnected = connected;

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -163,16 +163,20 @@
                     (if (and follow-redirects
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
-                        (request (assoc opts ; follow 301 and 302 redirect
-                                   :url (.toString ^URI (.resolve (URI. url) ^String
-                                                                  (.get headers "location")))
-                                   :response response
-                                   :method (if (and (not allow-unsafe-redirect-methods)
-                                                    (#{301 302 303} status))
-                                             :get ;; change to :GET
-                                             (:method opts))  ;; do not change
-                                   :trace-redirects (conj trace-redirects url))
-                                 callback)
+                        (let [location (.toString (.resolve (URI. url)
+                                                            ^String (.get headers "location")))
+                              change-to-get (and (not allow-unsafe-redirect-methods)
+                                                 (#{301 302 303} status))]
+                          (request (assoc opts ; follow 301 and 302 redirect
+                                     :url location
+                                     :response response
+                                     :query-params (if change-to-get nil (:query-params opts))
+                                     :form-params (if change-to-get nil (:form-params opts))
+                                     :method (if change-to-get
+                                               :get ;; change to :GET
+                                               (:method opts))  ;; do not change
+                                     :trace-redirects (conj trace-redirects url))
+                                   callback))
                         (deliver-resp {:opts (dissoc opts :response)
                                        :error (Exception. (str "too many redirects: "
                                                                (count trace-redirects)))}))


### PR DESCRIPTION
- clearing form and query params on 301-303 redirects (fixes #209 and problem when web app redirects after POST)
- SO_KEEPALIVE and TCP_NODELAY on client sockets (this prevents some connection resets when dealing with long running server-side stuff; plus these are a standard browser socket options)