### PR TITLE
Fix tests in travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 *jar
 .classpath
 .lein-deps-sum

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: clojure
+lein: lein
+script: lein test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
 lein: lein
-script: lein test
+script: lein test :travis

--- a/README.md
+++ b/README.md
@@ -1,34 +1,38 @@
 # HTTP Kit
 
-## High-performance event-driven HTTP client/server for Clojure
+### A high-performance event-driven HTTP client+server for Clojure
 
-See **[http-kit.org](http://http-kit.org)** for documentation, examples, benchmarks, etc.
-
-Current [semantic](http://semver.org/) versions:
+[CHANGELOG](https://github.com/http-kit/http-kit/blob/master/history.md) | Current [semantic](http://semver.org/) version/s:
 
 ```clojure
 [http-kit "2.1.19"]        ; Stable
 [http-kit "2.1.21-alpha2"] ; Dev
 ```
 
-## Library status
+[![Build Status](https://travis-ci.org/http-kit/http-kit.svg?branch=master)](https://travis-ci.org/http-kit/http-kit)
 
-http-kit's author ([@shenfeng]) unfortunately hasn't had much time to maintain http-kit recently. In an attempt to help out I'll be doing issue triage, accepting minor/obvious PRs, etc. My own time's pretty limited so **contributors welcome**: looking for pull requests, feedback/ideas, and help dealing with GitHub issues, etc. Please contact me if you'd be interested in lending a hand. Thank you!
+See [http-kit.org](http://http-kit.org) for documentation, examples, benchmarks, etc. (may be a little out of date).
+
+## Project status
+
+http-kit's author ([@shenfeng]) unfortunately hasn't had much time to maintain http-kit recently. To help out I'll be doing basic issue triage, accepting minor/obvious PRs, etc.
+
+A big thank you to the **[current contributors](https://github.com/http-kit/http-kit/graphs/contributors)** for keeping the project going! **Additional contributors welcome**: please ping me if you'd be interested in lending a hand.
 
 \- [@ptaoussanis]
 
 ### Hack locally
 
-Hacker friendly: Zero dependency, written from ground-up with only ~3.5k lines of code (including java), clean and tidy.
+Hacker friendly: zero dependencies, written from the ground-up with only ~3.5k lines of code (including java), clean and tidy.
 
 ```sh
-# modify as you want, unit tests back you up
+# Modify as you want, unit tests back you up:
 lein test
 
-# may be useful. more info, see the code server_test.clj
+# May be useful (more info), see `server_test.clj`:
 ./scripts/start_test_server
 
-# some numbers about how fast can http-kit's client can run
+# Some numbers on how fast can http-kit's client can run:
 lein test :benchmark
 ```
 
@@ -36,13 +40,9 @@ lein test :benchmark
 
 Please use the [GitHub issues page](https://github.com/http-kit/http-kit/issues) for feature suggestions, bug reports, or general discussions. Current contributors are listed [here](https://github.com/http-kit/http-kit/graphs/contributors). The http-kit.org website is also on GitHub [here](https://github.com/http-kit/http-kit.github.com).
 
-### Change log
-
-[history.md](https://github.com/http-kit/http-kit/blob/master/history.md)
-
 ### License
 
-Copyright &copy; 2012-2015 [Feng Shen](http://shenfeng.me/). Distributed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+Copyright &copy; 2012-2016 [Feng Shen](http://shenfeng.me/). Distributed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
 
 [@shenfeng]: https://github.com/shenfeng
 [@ptaoussanis]: https://github.com/ptaoussanis

--- a/history.md
+++ b/history.md
@@ -19,7 +19,13 @@ HTTP Client:
   No changes
 
 ## 2.1.19 (2014 Aug 25)
-  ??
+HTTP Server:
+  1. #108 Duplicate headers cons'ed into list don't conform with ring spec
+  2. #152 Exception when stopping server
+  3. #155 Call on-close handlers on calling thread when threadpool is closed
+HTTP Client:
+  1. #149 Added methods required for CalDAV (@robbieh)
+  2. #157 Default HttpClient callback thread pool is always one (@dlebrero)
 
 ## 2.1.18 (2014/4/18)
 HTTP Server:

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :global-vars {*warn-on-reflection* true}
 
   :dependencies
-  [[org.clojure/clojure "1.4.0"]]
+  [[org.clojure/clojure "1.5.1"]]
 
   :plugins
   [[lein-swank   "1.4.4"]
@@ -31,8 +31,7 @@
    :all (fn [_] true)}
 
   :profiles
-  {:1.5  {:dependencies [[org.clojure/clojure "1.5.1"]]}
-   :test {:java-source-paths ["test/java" "src/java"]}
+  {:test {:java-source-paths ["test/java" "src/java"]}
    :dev  {:dependencies
           [[junit/junit "4.8.2"]
            [org.clojure/tools.logging "0.2.6"]

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
   :jar-exclusions [#".*java$"]
   :test-selectors
   {:default (complement :benchmark)
+   :travis  (complement #(or (:benchmark %) (:skip-travis %)))
    :benchmark :benchmark
    :all (fn [_] true)}
 

--- a/src/java/org/httpkit/HeaderMap.java
+++ b/src/java/org/httpkit/HeaderMap.java
@@ -85,6 +85,10 @@ public class HeaderMap {
         for (int i = 0; i < total; i += 2) {
             String k = (String) arrays[i];
             Object v = arrays[i + 1];
+            // omit invalid headers and prevent possible exceptions (e.g., NullPointerException)
+            if (k == null || v == null) {
+                continue;
+            }
             // ring spec says it could be a seq
             if (v instanceof Seqable) {
                 ISeq seq = ((Seqable) v).seq();

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -104,13 +104,17 @@ public class HttpUtils {
             return readAll((File) body);
         } else if (body instanceof Seqable) {
             ISeq seq = ((Seqable) body).seq();
-            DynamicBytes b = new DynamicBytes(seq.count() * 512);
-            while (seq != null) {
-                b.append(seq.first().toString(), UTF_8);
-                seq = seq.next();
+            if (seq == null) {
+                return null;
+            } else {
+                DynamicBytes b = new DynamicBytes(seq.count() * 512);
+                while (seq != null) {
+                    b.append(seq.first().toString(), UTF_8);
+                    seq = seq.next();
+                }
+                return ByteBuffer.wrap(b.get(), 0, b.length());
             }
-            return ByteBuffer.wrap(b.get(), 0, b.length());
-            // makes ultimate optimization possible: no copy
+        // makes ultimate optimization possible: no copy
         } else if (body instanceof ByteBuffer) {
             return (ByteBuffer) body;
         } else {

--- a/src/java/org/httpkit/server/HttpAtta.java
+++ b/src/java/org/httpkit/server/HttpAtta.java
@@ -2,8 +2,8 @@ package org.httpkit.server;
 
 public class HttpAtta extends ServerAtta {
 
-    public HttpAtta(int maxBody, int maxLine) {
-        decoder = new HttpDecoder(maxBody, maxLine);
+    public HttpAtta(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption) {
+        decoder = new HttpDecoder(maxBody, maxLine, proxyProtocolOption);
     }
 
     public final HttpDecoder decoder;

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -1,11 +1,21 @@
 package org.httpkit.server;
 
-import org.httpkit.*;
-
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.httpkit.HttpMethod;
+import org.httpkit.HttpUtils;
+import org.httpkit.HttpVersion;
+import org.httpkit.LineReader;
+import org.httpkit.LineTooLargeException;
+import org.httpkit.ProtocolException;
+import org.httpkit.RequestTooLargeException;
 
 import static org.httpkit.HttpUtils.*;
 import static org.httpkit.HttpVersion.HTTP_1_0;
@@ -14,13 +24,36 @@ import static org.httpkit.HttpVersion.HTTP_1_1;
 public class HttpDecoder {
 
     public enum State {
-        ALL_READ, READ_INITIAL, READ_HEADER, READ_FIXED_LENGTH_CONTENT, READ_CHUNK_SIZE, READ_CHUNKED_CONTENT, READ_CHUNK_FOOTER, READ_CHUNK_DELIMITER,
+        ALL_READ, CONNECTION_OPEN, READ_INITIAL, READ_HEADER, READ_FIXED_LENGTH_CONTENT, READ_CHUNK_SIZE, READ_CHUNKED_CONTENT, READ_CHUNK_FOOTER, READ_CHUNK_DELIMITER,
     }
 
-    private State state = State.READ_INITIAL;
+    /**
+     * Pattern for matching numbers 0 to 255.  We use this in the IPV4 address pattern to prevent invalid sequences
+     * from be parsed by InetAddress.getByName and thus being treated as a name instead of an address.
+     */
+    private static final String IPV4SEG = "(?:0|1\\d{0,2}|2(?:[0-4]\\d*|5[0-5]?|[6-9])?|[3-9]\\d?)";
+    private static final String IPV4ADDR = IPV4SEG + "(?:\\." + IPV4SEG + "){3}";
+    /**
+     * Pattern for a port number.  We are not as strict in our pattern matching as we are with ipv4 address
+     * and instead rely upon Integer.parseInt and a range check.  Port 0 is invalid, so we disallow that here.
+     */
+    private static final String PORT = "[1-9]\\d{0,4}";
+    /**
+     * The PROXY protocol header is quite strict in what it allows, specifying for example that only
+     * a single space character (\x20) is allowed between components.
+     */
+    private static final Pattern PROXY_PATTERN = Pattern.compile(
+        "PROXY\\x20TCP4\\x20(" + IPV4ADDR + ")\\x20(" + IPV4ADDR +")\\x20(" + PORT + ")\\x20(" + PORT + ")"
+    );
+
+    private State state;
+    private ProxyProtocolOption proxyProtocolOption;
     private int readRemaining = 0; // bytes need read
     private int readCount = 0; // already read bytes count
 
+    private String xForwardedFor;
+    private String xForwardedProto;
+    private int xForwardedPort;
     HttpRequest request; // package visible
     private Map<String, Object> headers = new TreeMap<String, Object>();
     byte[] content;
@@ -28,9 +61,53 @@ public class HttpDecoder {
     private final int maxBody;
     private final LineReader lineReader;
 
-    public HttpDecoder(int maxBody, int maxLine) {
+    public HttpDecoder(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption) {
         this.maxBody = maxBody;
         this.lineReader = new LineReader(maxLine);
+        this.proxyProtocolOption = (proxyProtocolOption == null)
+            ? ProxyProtocolOption.DISABLED : proxyProtocolOption;
+
+        this.state = (proxyProtocolOption == ProxyProtocolOption.DISABLED)
+            ? State.READ_INITIAL : State.CONNECTION_OPEN;
+    }
+
+    private boolean parseProxyLine(String line) throws ProtocolException {
+        // PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n
+        if (!line.startsWith("PROXY ")) {
+            return false;
+        }
+
+        final Matcher m = PROXY_PATTERN.matcher(line);
+        if (!m.matches()) {
+            throw new ProtocolException("Unsupported or malformed proxy header: "+line);
+        }
+
+        try {
+            final InetAddress clientAddr = InetAddress.getByName(m.group(1));
+            final InetAddress proxyAddr = InetAddress.getByName(m.group(2));
+
+            final int clientPort = Integer.parseInt(m.group(3), 10);
+            final int proxyPort = Integer.parseInt(m.group(4), 10);
+
+            if (((clientPort | proxyPort) & ~0xffff) != 0) {
+                throw new ProtocolException("Invalid port number: "+line);
+            }
+
+            xForwardedFor = clientAddr.getHostAddress();
+            if (proxyPort == 80) {
+                xForwardedProto = "http";
+            } else if (proxyPort == 443) {
+                xForwardedProto = "https";
+            }
+            xForwardedPort = proxyPort;
+
+            return true;
+
+        } catch (NumberFormatException ex) {
+            throw new ProtocolException("Malformed port in: "+line);
+        } catch (UnknownHostException ex) {
+            throw new ProtocolException("Malformed address in: "+line);
+        }
     }
 
     private void createRequest(String sb) throws ProtocolException {
@@ -79,6 +156,25 @@ public class HttpDecoder {
             switch (state) {
                 case ALL_READ:
                     return request;
+                case CONNECTION_OPEN:
+                    line = lineReader.readLine(buffer);
+                    if (line != null) {
+                        // parseProxyLines returns true if the line parsed
+                        // false if it was not a PROXY line
+                        // or throws ProtocolException, if the PROXY line is malformed or unsupported.
+                        if (parseProxyLine(line)) {
+                            // valid proxy header
+                            state = State.READ_INITIAL;
+                        } else if (proxyProtocolOption == ProxyProtocolOption.OPTIONAL) {
+                            // did not parse as a proxy header, try to create a request from it
+                            // as the READ_INITIAL state would.
+                            createRequest(line);
+                            state = State.READ_HEADER;
+                        } else {
+                            throw new ProtocolException("Expected PROXY header, got: "+line);
+                        }
+                    }
+                    break;
                 case READ_INITIAL:
                     line = lineReader.readLine(buffer);
                     if (line != null) {
@@ -154,6 +250,12 @@ public class HttpDecoder {
 
     private void readHeaders(ByteBuffer buffer) throws LineTooLargeException,
             RequestTooLargeException, ProtocolException {
+        if (proxyProtocolOption == ProxyProtocolOption.OPTIONAL
+            || proxyProtocolOption == ProxyProtocolOption.ENABLED) {
+            headers.put("x-forwarded-for", xForwardedFor);
+            headers.put("x-forwarded-proto", xForwardedProto);
+            headers.put("x-forwarded-port", xForwardedPort);
+        }
         String line = lineReader.readLine(buffer);
         while (line != null && !line.isEmpty()) {
             HttpUtils.splitAndAddHeader(line, headers);

--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -253,9 +253,11 @@ public class HttpServer implements Runnable {
                         selector.wakeup();
                     } else if (!atta.isKeepAlive()) {
                         pending.add(new PendingKey(key, CLOSE_NORMAL));
+                        selector.wakeup();
                     }
                 } catch (IOException e) {
                     pending.add(new PendingKey(key, CLOSE_AWAY));
+                    selector.wakeup();
                 }
             } else {
                 // If has pending write, order should be maintained. (WebSocket)
@@ -270,7 +272,8 @@ public class HttpServer implements Runnable {
         while (true) {
             try {
                 PendingKey k;
-                while ((k = pending.poll()) != null) {
+                while (!pending.isEmpty()) {
+                    k = pending.poll();
                     if (k.Op == PendingKey.OP_WRITE) {
                         if (k.key.isValid()) {
                             k.key.interestOps(OP_WRITE);

--- a/src/java/org/httpkit/server/ProxyProtocolOption.java
+++ b/src/java/org/httpkit/server/ProxyProtocolOption.java
@@ -1,0 +1,10 @@
+package org.httpkit.server;
+
+/**
+ * Created by jeffi on 7/16/15.
+ */
+public enum ProxyProtocolOption {
+    DISABLED,
+    ENABLED,
+    OPTIONAL
+}

--- a/src/java/org/httpkit/server/WSDecoder.java
+++ b/src/java/org/httpkit/server/WSDecoder.java
@@ -149,6 +149,7 @@ public class WSDecoder {
                         if (finalFlag) {
                             if (fragmentedOpCode > 0)
                               opcode = fragmentedOpCode;
+                            fragmentedOpCode = -1;
                             switch (opcode) {
                                 case OPCODE_TEXT:
                                     return new Frame.TextFrame(content);

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -59,20 +59,20 @@
 (defn- coerce-req
   [{:keys [url method body insecure? query-params form-params multipart] :as req}]
   (let [r (assoc req
-            :url (if query-params
-                   (if (neg? (.indexOf ^String url (int \?)))
-                     (str url "?" (query-string query-params))
-                     (str url "&" (query-string query-params)))
-                   url)
-            :sslengine (or (:sslengine req)
-                           (when (:insecure? req) (SslContextFactory/trustAnybody)))
-            :method    (HttpMethod/fromKeyword (or method :get))
-            :headers   (prepare-request-headers req)
+                 :url (if query-params
+                        (if (neg? (.indexOf ^String url (int \?)))
+                          (str url "?" (query-string query-params))
+                          (str url "&" (query-string query-params)))
+                        url)
+                 :sslengine (or (:sslengine req)
+                                (when (:insecure? req) (SslContextFactory/trustAnybody)))
+                 :method    (HttpMethod/fromKeyword (or method :get))
+                 :headers   (prepare-request-headers req)
             ;; :body ring body: null, String, seq, InputStream, File, ByteBuffer
-            :body      (if form-params (query-string form-params) body))]
+                 :body      (if form-params (query-string form-params) body))]
     (if multipart
       (let [entities (into (map (fn [{:keys [name content filename]}]
-                             (MultipartEntity. name content filename)) multipart)
+                                  (MultipartEntity. name content filename)) multipart)
                            (map (fn [[k v]] (MultipartEntity. k v nil)) form-params))
             boundary (MultipartEntity/genBoundary entities)]
         (-> r
@@ -164,14 +164,14 @@
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
                         (request (assoc opts ; follow 301 and 302 redirect
-                                   :url (.toString ^URI (.resolve (URI. url) ^String
-                                                                  (.get headers "location")))
-                                   :response response
-                                   :method (if (and (not allow-unsafe-redirect-methods)
-                                                    (#{301 302 303} status))
-                                             :get ;; change to :GET
-                                             (:method opts))  ;; do not change
-                                   :trace-redirects (conj trace-redirects url))
+                                        :url (.toString ^URI (.resolve (URI. url) ^String
+                                                                       (.get headers "location")))
+                                        :response response
+                                        :method (if (and (not allow-unsafe-redirect-methods)
+                                                         (#{301 302 303} status))
+                                                  :get ;; change to :GET
+                                                  (:method opts))  ;; do not change
+                                        :trace-redirects (conj trace-redirects url))
                                  callback)
                         (deliver-resp {:opts (dissoc opts :response)
                                        :error (Exception. (str "too many redirects: "

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -99,7 +99,9 @@
 (defn request
   "Issues an async HTTP request and returns a promise object to which the value
   of `(callback {:opts _ :status _ :headers _ :body _})` or
-     `(callback {:opts _ :error _})` will be delivered.
+     `(callback {:opts _ :error _})` will be delivered. 
+  The latter will be delivered on client errors only, not on http errors which will be 
+  contained in the :status of the first. 
 
   When unspecified, `callback` is the identity
 

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -99,9 +99,9 @@
 (defn request
   "Issues an async HTTP request and returns a promise object to which the value
   of `(callback {:opts _ :status _ :headers _ :body _})` or
-     `(callback {:opts _ :error _})` will be delivered. 
-  The latter will be delivered on client errors only, not on http errors which will be 
-  contained in the :status of the first. 
+     `(callback {:opts _ :error _})` will be delivered.
+  The latter will be delivered on client errors only, not on http errors which will be
+  contained in the :status of the first.
 
   When unspecified, `callback` is the identity
 
@@ -164,7 +164,7 @@
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
                         (request (assoc opts ; follow 301 and 302 redirect
-                                        :url (.toString ^URI (.resolve (URI. url) ^String
+                                        :url (str (.resolve (URI. url) ^String
                                                                        (.get headers "location")))
                                         :response response
                                         :method (if (and (not allow-unsafe-redirect-methods)

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -5,40 +5,56 @@
 
 ;;;; Ring server
 
-(defn- to-proxy-enum
-  [opt]
-  (case opt
-    :enable   ProxyProtocolOption/ENABLED
-    :disable  ProxyProtocolOption/DISABLED
-    :optional ProxyProtocolOption/OPTIONAL))
-
 (defn run-server
-  "Starts (mostly*) Ring-compatible HTTP server and returns a function that stops
-  the server, which can take an optional timeout(ms)
-  param to wait existing requests to be finished, like (f :timeout 100).
+  "Starts HTTP server and returns
+    (fn [& {:keys [timeout] ; Timeout (msecs) to wait on existing reqs to complete
+           :or   {timeout 100}}])
 
-  * See http://http-kit.org/migration.html for differences."
+  Server is mostly Ring compatible, see http://http-kit.org/migration.html
+  for differences.
+
+  Options:
+    :ip                 ; Which ip (if has many ips) to bind
+    :port               ; Which port listen incomming request
+    :thread             ; Http worker thread count
+    :queue-size         ; Max job queued before reject to project self
+    :max-body           ; Max http body: 8m
+    :max-ws             ; Max websocket message size
+    :max-line           ; Max http inital line length
+    :proxy-protocol     ; Proxy protocol e/o #{:disable :enable :optional}
+    :worker-name-prefix ; Woker thread name prefix"
+
   [handler
-   & [{:keys [port thread ip max-body max-line worker-name-prefix queue-size max-ws proxy-protocol]
-       :or   {ip "0.0.0.0" ; which ip (if has many ips) to bind
-              port 8090    ; which port listen incomming request
-              thread 4     ; http worker thread count
-              queue-size 20480 ; max job queued before reject to project self
-              worker-name-prefix "worker-" ; woker thread name prefix
-              max-body 8388608 ; max http body: 8m
-              max-ws   4194304 ; max websocket message size: 4m
-              max-line 4096    ; max http inital line length: 4K
-              proxy-protocol :disable ; proxy protocol is disabled by default
-              }}]]
+   & [{:keys [ip port thread queue-size max-body max-ws max-line
+              proxy-protocol worker-name-prefix]
+
+       :or   {ip         "0.0.0.0"
+              port       8090
+              thread     4
+              queue-size 20480
+              max-body   8388608
+              max-ws     4194304
+              max-line   4096
+              proxy-protocol :disable
+              worker-name-prefix "worker-"}}]]
+
   (let [h (RingHandler. thread handler worker-name-prefix queue-size)
-        s (HttpServer. ip port h max-body max-line max-ws (to-proxy-enum proxy-protocol))]
+        proxy-enum (case proxy-protocol
+                     :enable   ProxyProtocolOption/ENABLED
+                     :disable  ProxyProtocolOption/DISABLED
+                     :optional ProxyProtocolOption/OPTIONAL)
+
+        s (HttpServer. ip port h max-body max-line max-ws proxy-enum)]
+
     (.start s)
-    (with-meta (fn stop-server [& {:keys [timeout] :or {timeout 100}}]
-                 ;; graceful shutdown:
-                 ;; 1. server stop accept new request
-                 ;; 2. wait for existing requests to finish
-                 ;; 3. close the server
-                 (.stop s timeout))
+    (with-meta
+      (fn stop-server [& {:keys [timeout] :or {timeout 100}}]
+        ;; graceful shutdown:
+        ;; 1. server stop accept new request
+        ;; 2. wait for existing requests to finish
+        ;; 3. close the server
+        (.stop s timeout))
+
       {:local-port (.getPort s)
        :server s})))
 

--- a/test/java/org/httpkit/server/MultiThreadHttpServerTest.java
+++ b/test/java/org/httpkit/server/MultiThreadHttpServerTest.java
@@ -47,7 +47,7 @@ class MultiThreadHandler implements IHandler {
 public class MultiThreadHttpServerTest {
     public static void main(String[] args) throws IOException {
         HttpServer server = new HttpServer("0.0.0.0", 9091, new MultiThreadHandler(), 20480,
-                2048, 1024 * 1024 * 4);
+                2048, 1024 * 1024 * 4, ProxyProtocolOption.DISABLED);
         server.start();
         System.out.println("Server started on :9091");
     }

--- a/test/java/org/httpkit/server/SingleThreadHttpServerTest.java
+++ b/test/java/org/httpkit/server/SingleThreadHttpServerTest.java
@@ -39,7 +39,7 @@ public class SingleThreadHttpServerTest {
         // concurrency 1024, 2000000 request, time: 16545ms; 120882.44 req/s;
         // receive: 93M data; 5.62 M/s
         HttpServer server = new HttpServer("0.0.0.0", 9091, new SingleThreadHandler(), 20480,
-                2048, 1024 * 1024 * 4);
+                2048, 1024 * 1024 * 4, ProxyProtocolOption.DISABLED);
         server.start();
 
         // 2012/11/28

--- a/test/java/org/httpkit/ws/WebSocketClient.java
+++ b/test/java/org/httpkit/ws/WebSocketClient.java
@@ -99,6 +99,8 @@ public class WebSocketClient {
             return ((TextWebSocketFrame) frame).getText();
         } else if (frame instanceof BinaryWebSocketFrame) {
             return frame.getBinaryData().array();
+        } else if (frame == null) {
+            throw new IllegalStateException("Couldn't get message after waiting for " + waitTimeout + " seconds.");
         }
         return frame;
     }

--- a/test/java/org/httpkit/ws/WebSocketClient.java
+++ b/test/java/org/httpkit/ws/WebSocketClient.java
@@ -93,7 +93,8 @@ public class WebSocketClient {
     }
 
     public Object getMessage() throws InterruptedException {
-        WebSocketFrame frame = queue.poll(5, TimeUnit.SECONDS);
+        int waitTimeout = 30; // Travis CI machines are sometimes very slow
+        WebSocketFrame frame = queue.poll(waitTimeout, TimeUnit.SECONDS);
         if (frame instanceof TextWebSocketFrame) {
             return ((TextWebSocketFrame) frame).getText();
         } else if (frame instanceof BinaryWebSocketFrame) {

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -50,8 +50,8 @@
   (GET "/p" [] (fn [req] (pr-str (:params req))))
   (ANY "/params" [] (fn [req] (-> req :params :param1)))
   (PUT "/body" [] (fn [req] {:body (:body req)
-                            :status 200
-                            :headers {"content-type" "text/plain"}}))
+                             :status 200
+                             :headers {"content-type" "text/plain"}}))
   (GET "/test-header" [] (fn [{:keys [headers]}] (str (get headers "test-header")))))
 
 (use-fixtures :once
@@ -124,13 +124,12 @@
 
     (testing "callback exception handling"
       (let [{^Exception error :error} @(http/get (str host "/get")
-                                      (fn [_] (throw (Exception. "Exception"))))]
+                                                 (fn [_] (throw (Exception. "Exception"))))]
         (is (= "Exception" (.getMessage error))))
 
       (let [{^Throwable error :error} @(http/get (str host "/get")
-                                      (fn [_] (throw (Throwable. "Throwable"))))]
+                                                 (fn [_] (throw (Throwable. "Throwable"))))]
         (is (= "Throwable" (.getMessage error)))))))
-
 
 (deftest test-unicode-encoding
   (let [u "高性能HTTPServer和Client"
@@ -242,7 +241,7 @@
                (java.io.FileInputStream. file) ; inputstream
                [(subs const-string 0 100) (subs const-string 100 length)] ; seqable
                (ByteBuffer/wrap (.getBytes (subs const-string 0 length))) ; byteBuffer
-               ]]
+]]
     (doseq [body bodys]
       (is (= length (count (:body @(http/put "http://127.0.0.1:4347/body"
                                              {:body body}))))))))
@@ -304,13 +303,12 @@
     (is (= "get" (:body @(http/post url {:as :text})))) ; should switch to get method
     (is (= "post" (:body @(http/post url {:as :text :allow-unsafe-redirect-methods true})))) ; should not change method
     (is (= "post" (:body @(http/post (str url "&code=307") {:as :text})))) ; should not change method
-    ))
+))
 
 (deftest test-multipart
   (is (= 200 (:status @(http/post "http://localhost:4347/multipart"
                                   {:multipart [{:name "comment" :content "httpkit's project.clj"}
                                                {:name "file" :content (clojure.java.io/file "project.clj") :filename "project.clj"}]})))))
-
 
 (deftest test-coerce-req
   "Headers should be the same regardless of multipart"
@@ -319,7 +317,6 @@
     (is (= (keys (:headers (coerce-req request)))
            (remove #(= % "Content-Type")
                    (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}])))))))))
-
 
 (deftest test-header-multiple-values
   (let [resp @(http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}})
@@ -335,8 +332,8 @@
                            ['(0) "0"]
                            ['("a" "b") "a,b"]]]
     (let [received (:body @(http/get "http://localhost:4347/test-header"
-                             {:headers {"test-header" sent}}))]
-        (is (= received expected)))))
+                                     {:headers {"test-header" sent}}))]
+      (is (= received expected)))))
 
 (defn- utf8 [^String s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
 
@@ -390,9 +387,7 @@
     ;; One header.
     HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-     [:headers {"content-length" "0"}]]
-
-    ))
+     [:headers {"content-length" "0"}]]))
 
 (deftest test-decode-body
   (are [method resp events] (= (decode method (utf8 resp)) events)
@@ -407,23 +402,21 @@
      [:headers {"content-length" "1"}]]
 
      ;; One byte.
-     HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n."
-     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-      [:headers {"content-length" "1"}]
-      [:body [46]]]
+    HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n."
+    [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
+     [:headers {"content-length" "1"}]
+     [:body [46]]]
 
      ;; One byte. The rest is ignored.
-     HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n..."
-     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-      [:headers {"content-length" "1"}]
-      [:body [46]]]
+    HttpMethod/GET "HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n..."
+    [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
+     [:headers {"content-length" "1"}]
+     [:body [46]]]
 
     ;; The body is omitted for HEAD requests.
     HttpMethod/HEAD "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n..."
     [[:init HttpVersion/HTTP_1_1 HttpStatus/OK]
-     [:headers {"content-length" "3"}]]
-
-    ))
+     [:headers {"content-length" "3"}]]))
 
 ;; @(http/get "http://127.0.0.1:4348" {:headers {"Connection" "Close"}})
 

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -233,7 +233,7 @@
                                 identity)
                  :headers :x-method read-string)))))
 
-(deftest test-string-file-inputstream-body []
+(deftest test-string-file-inputstream-body
   (let [length (+ (rand-int (* 1024 1024 5)) 100)
         file (gen-tempfile length ".txt")
         bodys [(subs const-string 0 length)    ;string
@@ -311,12 +311,12 @@
                                                {:name "file" :content (clojure.java.io/file "project.clj") :filename "project.clj"}]})))))
 
 (deftest test-coerce-req
-  "Headers should be the same regardless of multipart"
-  (let [coerce-req #'org.httpkit.client/coerce-req
-        request {:basic-auth ["user" "pass"]}]
-    (is (= (keys (:headers (coerce-req request)))
-           (remove #(= % "Content-Type")
-                   (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}])))))))))
+  (testing "Headers should be the same regardless of multipart"
+    (let [coerce-req #'org.httpkit.client/coerce-req
+          request {:basic-auth ["user" "pass"]}]
+      (is (= (keys (:headers (coerce-req request)))
+             (remove #(= % "Content-Type")
+                     (keys (:headers (coerce-req (assoc request :multipart [{:name "foo" :content "bar"}]))))))))))
 
 (deftest test-header-multiple-values
   (let [resp @(http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}})

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -123,11 +123,11 @@
         (is (= 200 (:status @(http/get url))))))
 
     (testing "callback exception handling"
-      (let [{error :error} @(http/get (str host "/get")
+      (let [{^Exception error :error} @(http/get (str host "/get")
                                       (fn [_] (throw (Exception. "Exception"))))]
         (is (= "Exception" (.getMessage error))))
 
-      (let [{error :error} @(http/get (str host "/get")
+      (let [{^Throwable error :error} @(http/get (str host "/get")
                                       (fn [_] (throw (Throwable. "Throwable"))))]
         (is (= "Throwable" (.getMessage error)))))))
 
@@ -266,7 +266,7 @@
       (is (string? body)))
     (let [body (:body @(http/get url {:as :stream}))]
       (is (instance? java.io.InputStream body)))
-    (let [body (:body @(http/get url {:as :byte-array}))]
+    (let [^bytes body (:body @(http/get url {:as :byte-array}))]
       (is (= 1024 (alength body))))))
 
 (deftest test-https
@@ -274,7 +274,7 @@
     (doseq [i (range 0 2)]
       (doseq [length (repeatedly 40 (partial rand-int (* 4 1024 1024)))]
         (let [{:keys [body error status]} @(http/get (get-url length) {:insecure? true})]
-          (if error (.printStackTrace error))
+          (if error (.printStackTrace ^Throwable error))
           (is (= length (count body)))))
       (doseq [length (repeatedly 40 (partial rand-int (* 4 1024 1024)))]
         (is (= length (-> @(http/get (get-url length)
@@ -338,7 +338,7 @@
                              {:headers {"test-header" sent}}))]
         (is (= received expected)))))
 
-(defn- utf8 [s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
+(defn- utf8 [^String s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
 
 (defn- decode
   [method buffer]

--- a/test/org/httpkit/proxy_test.clj
+++ b/test/org/httpkit/proxy_test.clj
@@ -10,7 +10,7 @@
    :timeout 30000 ;ms
    :method (:request-method req)
    :headers (assoc (:headers req)
-              "X-Forwarded-For" (:remote-addr req))
+                   "X-Forwarded-For" (:remote-addr req))
    :body (:body req)})
 
 (defn handler [req]

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -310,7 +310,10 @@
     (is (re-find #"200" resp))
     (is (re-find #"Keep-Alive" resp))))
 
-(deftest test-ipv6
+(deftest ^:skip-travis test-ipv6
+  ;; Skipping this on Travis because of difficulties with [::1] IPv6
+  ;; on AWS CIs, Ref. https://github.com/travis-ci/travis-ci/issues/4964
+
   ;; TODO add more
   (is (= "hello world" (:body (http/get "http://[::1]:4347/")))))
 

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -90,7 +90,7 @@
                           :body "canceled"}))))))
 
 (defn streaming-demo [request]
-  (let [time (Integer/valueOf (or (-> request :params :i) 200))]
+  (let [time (Integer/valueOf (or ^String (-> request :params :i) 200))]
     (with-channel request channel
       (on-close channel (fn [status]
                           (println channel "closed" status)))

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -106,11 +106,14 @@
   (GET "/headers" [] many-headers-handler)
   (ANY "/spec" [] (fn [req] (pr-str (dissoc req :body :async-channel))))
   (GET "/string" [] (fn [req] {:status 200
-                              :headers {"Content-Type" "text/plain"}
-                              :body "Hello World"}))
+                               :headers {"Content-Type" "text/plain"}
+                               :body "Hello World"}))
   (GET "/iseq" [] (fn [req] {:status 200
-                            :headers {"Content-Type" "text/plain"}
-                            :body (range 1 10)}))
+                             :headers {"Content-Type" "text/plain"}
+                             :body (range 1 10)}))
+  (GET "/iseq-empty" [] (fn [req] {:status 200
+                                   :headers {"Content-Type" "text/plain"}
+                                   :body '()}))
   (GET "/file" [] (wrap-file-info file-handler))
   (GET "/ws" [] (fn [req]
                   (with-channel req con
@@ -119,7 +122,7 @@
   (GET "/inputstream" [] inputstream-handler)
   (POST "/multipart" [] multipart-handler)
   (POST "/chunked-input" [] (fn [req] {:status 200
-                                      :body (str (:content-length req))}))
+                                       :body (str (:content-length req))}))
   (GET "/length" [] (fn [req]
                       (let [l (-> req :params :length to-int)]
                         {:status 200

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -187,12 +187,12 @@
 
 (deftest test-body-file
   (doseq [length (range 1 (* 1024 1024 8) 1439987)]
-    (let [resp (http/get "http://localhost:4347/file?l=" length)]
+    (let [resp (http/get (str "http://localhost:4347/file?l=" length))]
       (is (= (:status resp) 200))
       (is (= (get-in resp [:headers "content-type"]) "text/plain"))
       (is (= length (count (:body resp)))))))
 
-(deftest test-body-file
+(deftest test-other-body-file
   (let [resp (http/get "http://localhost:4347/file")]
     (is (= (:status resp) 200))
     (is (= (get-in resp [:headers "content-type"]) "text/plain"))

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -30,10 +30,10 @@
   (let [count (or (-> req :params :count to-int) 20)]
     {:status 200
      :headers (assoc
-                  (into {} (map (fn [idx]
-                                  [(str "key-" idx) (str "value-" idx)])
-                                (range 0 (inc count))))
-                "x-header-1" ["abc" "def"])}))
+               (into {} (map (fn [idx]
+                               [(str "key-" idx) (str "value-" idx)])
+                             (range 0 (inc count))))
+               "x-header-1" ["abc" "def"])}))
 
 (defn multipart-handler [req]
   (let [{:keys [title file]} (:params req)]
@@ -66,7 +66,7 @@
                          {:body p})
                false))        ;; do not close
       (send! channel "" true) ;; same as (close channel)
-      )))
+)))
 
 (defn slow-server-handler [req]
   (with-channel req channel
@@ -143,7 +143,6 @@
                       (let [server (run-server
                                     (site test-routes) {:port 4347})]
                         (try (f) (finally (server))))))
-
 
 (deftest test-ring-spec
   (let [req (-> (http/get "http://localhost:4347/spec?c=d"

--- a/test/org/httpkit/test_util.clj
+++ b/test/org/httpkit/test_util.clj
@@ -21,7 +21,7 @@
          (.write w ^bytes (.getBytes (subs const-string 0 size))))
        tmp)))
 
-(defn to-int [int-str] (Integer/valueOf int-str))
+(defn to-int [^String int-str] (Integer/valueOf int-str))
 
 (def channel-closed (atom false))
 

--- a/test/org/httpkit/test_util.clj
+++ b/test/org/httpkit/test_util.clj
@@ -14,12 +14,12 @@
 (defn ^File gen-tempfile
   "generate a tempfile, the file will be deleted before jvm shutdown"
   ([size extension]
-     (let [tmp (doto
-                   (File/createTempFile "tmp_" extension)
-                 (.deleteOnExit))]
-       (with-open [w (FileOutputStream. tmp)]
-         (.write w ^bytes (.getBytes (subs const-string 0 size))))
-       tmp)))
+   (let [tmp (doto
+              (File/createTempFile "tmp_" extension)
+               (.deleteOnExit))]
+     (with-open [w (FileOutputStream. tmp)]
+       (.write w ^bytes (.getBytes (subs const-string 0 size))))
+     tmp)))
 
 (defn to-int [^String int-str] (Integer/valueOf int-str))
 

--- a/test/org/httpkit/utils_test.clj
+++ b/test/org/httpkit/utils_test.clj
@@ -9,7 +9,7 @@
 
 (defn charset [name] (Charset/forName name))
 
-(defn detect-charset [headers body]
+(defn detect-charset [headers ^String body]
   (let [b (doto (DynamicBytes. 128)
             (.append body))]
     (HttpUtils/detectCharset headers b)))

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -152,9 +152,9 @@
     (dotimes [_ 5]
       (let [length (min 1024 (rand-int 10024))
             data (byte-array length (take length (repeatedly #(byte (rand-int 126)))))
-            sorted-data (doto (aclone data) (java.util.Arrays/sort))]
+            ^bytes sorted-data (doto (aclone data) (java.util.Arrays/sort))]
         (.sendBinaryData client data)
-        (let [output (.getMessage client)]
+        (let [^bytes output (.getMessage client)]
           (is (java.util.Arrays/equals sorted-data output)))))
     (.close client)))
 

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -205,10 +205,10 @@
                                   (deliver latch true))
                           :close (fn [con status]
                                    ;; (println "close:" con status)
-                                   )
+)
                           :open (fn [con]
                                   ;; (println "opened:" con)
-                                  ))]
+))]
       ;; (h/send ws :byte (byte-array 10)) not implemented yet
       (let [msg "testing12"]
         (h/send ws :text msg)

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -118,8 +118,8 @@
                             "\nreceive:\n" r))
               (is false))))
         (let [d (subs const-string 0 120)]
-          (= d (.ping client d))
-          (= d (.pong client d)))))
+          (is (= d (.ping client d)))
+          (is (= d (.pong client d))))))
     (.close client)))
 
 (deftest test-sent-message-in-body      ; issue #14


### PR DESCRIPTION
This fixes randomly failing tests from org.httpkit.ws-test in Travis environment. The root cause of failures seems to be the slowness of Travis machines. WebSocketClient in tests uses method `queue.poll(5, TimeUnit.SECONDS). Sometimes 5 seconds is not enough for first message to arrive. ArrayBlockingQueue.poll method does not throw any exception on this but returns null instead. This is a bit misleading because it can also mean that queue is empty.

However, increasing wait time to 10 seconds seems to fix the problem. I ran tests multiple times in Travis and they do not fail anymore.