### PR TITLE
[circleci] Move to CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: clojure
-lein: lein
-script: lein test :travis

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - lein test :ci

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   :jar-exclusions [#"^java.*"] ; exclude the java directory in source path
   :test-selectors
   {:default (complement :benchmark)
-   :travis  (complement #(or (:benchmark %) (:skip-travis %)))
+   :ci  (complement #(or (:benchmark %) (:skip-ci %)))
    :benchmark :benchmark
    :all (fn [_] true)}
 

--- a/test/java/org/httpkit/ws/WebSocketClient.java
+++ b/test/java/org/httpkit/ws/WebSocketClient.java
@@ -93,7 +93,7 @@ public class WebSocketClient {
     }
 
     public Object getMessage() throws InterruptedException {
-        int waitTimeout = 50; // Travis CI machines are sometimes VERY slow
+        int waitTimeout = 20;
         WebSocketFrame frame = queue.poll(waitTimeout, TimeUnit.SECONDS);
         if (frame instanceof TextWebSocketFrame) {
             return ((TextWebSocketFrame) frame).getText();

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -312,8 +312,8 @@
     (is (re-find #"200" resp))
     (is (re-find #"Keep-Alive" resp))))
 
-(deftest ^:skip-travis test-ipv6
-  ;; Skipping this on Travis because of difficulties with [::1] IPv6
+(deftest ^:skip-ci test-ipv6
+  ;; Skipping this on CI because of difficulties with [::1] IPv6
   ;; on AWS CIs, Ref. https://github.com/travis-ci/travis-ci/issues/4964
 
   ;; TODO add more


### PR DESCRIPTION
I've been testing http-kit's tests on CircleCI and they don't seem to be running into the same timeout issues that afflicted us on Travis. They're also free for open source so I just suggest we set that up as our CI server instead of Travis. 