### PR TITLE
Adding fix to allow https requests through http-proxy

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -281,7 +281,8 @@ public class HttpClient implements Runnable {
             cb.onThrowable(e);
             return;
         }
-        if ("https".equals(scheme)) {
+        if ((proxyUri == null && "https".equals(scheme))
+            || (proxyUri != null && "https".equals(proxyUri.getScheme()))) {
             if (engine == null) {
                 engine = DEFAULT_CONTEXT.createSSLEngine();
             }

--- a/test/org/httpkit/client_proxy_test.clj
+++ b/test/org/httpkit/client_proxy_test.clj
@@ -2,10 +2,10 @@
   (:require [clj-http.client :as clj-http]
             [clojure.data.codec.base64 :as b64]
             [clojure.test :refer :all]
-            [compojure.core :refer [GET defroutes]]
+            [compojure.core :refer [GET defroutes wrap-routes]]
             [org.httpkit.client :as http]
+            [org.httpkit.ring-request-proxy :refer [proxy-request]]
             [org.httpkit.server :refer [run-server]]
-            [ring-request-proxy.core :as proxy]
             [ring.adapter.jetty :refer [run-jetty]]
             [ring.middleware.defaults :as defaults]
             [ring.middleware.basic-authentication :refer [wrap-basic-authentication]]))
@@ -17,55 +17,93 @@
   (and (= name "user")
        (= pass "pass")))
 
+(def proxy-handler (proxy-request {:identifer-fn :server-name
+                                   :allow-insecure-ssl true
+                                   :host-fn (fn [{:keys [remote-addr server-port scheme] :as opts}]
+                                              (cond
+                                                (= 4347 server-port)
+                                                (str "http://" remote-addr ":" server-port)
+                                                (= 9898 server-port)
+                                                (str "https://" remote-addr ":" server-port)))}))
+
 (use-fixtures :once
   (fn [f]
     (let [server (run-server
                   (defaults/wrap-defaults test-routes defaults/site-defaults)
                   {:port 4347})
+          ssl-server (run-jetty
+                      (defaults/wrap-defaults test-routes defaults/site-defaults)
+                      {:port 14347 :join? false :ssl-port 9898 :ssl? true :http? false
+                       :key-password "123456" :keystore "test/ssl_keystore"})
+          ssl-proxy-server (run-jetty
+                            proxy-handler
+                            {:port 14348 :join? false :ssl-port 9899 :ssl? true :http? false
+                             :key-password "123456" :keystore "test/ssl_keystore"})
           proxy-server (run-server
-                        (proxy/proxy-request
-                         {:identifer-fn :server-name
-                          :host-fn (fn [{:keys [uri] :as opts}] uri)})
-                        {:port 4348})
+                        proxy-handler
+                        {:port 4348 :join? false :ssl? false})
           auth-proxy-server (run-server
-                             (-> (proxy/proxy-request
-                                  {:identifer-fn :server-name
-                                   :host-fn (fn [{:keys [uri] :as opts}] uri)})
+                             (-> proxy-handler
                                  (wrap-basic-authentication authenticated?))
                              {:port 4349})]
-      (try (f) (finally (server) (proxy-server) (auth-proxy-server))))))
+      (try (f) (finally (server) (proxy-server) (auth-proxy-server)
+                        (.stop ssl-server) (.stop ssl-proxy-server))))))
 
 (deftest test-control
   (testing "no proxy, for sanity checking"
-    (let [resp @(http/get "http://localhost:4347/get")]
+    (let [resp @(http/get "http://127.0.0.1:4347/get")]
+      (is (= 200 (:status resp)))
+      (is (= "hello world" (:body resp)))))
+  (testing "no proxy + ssl, for sanity checking"
+    (let [resp @(http/get "https://127.0.0.1:9898/get" {:insecure? true})]
       (is (= 200 (:status resp)))
       (is (= "hello world" (:body resp))))))
 
 (deftest test-compare-to-clj
   (testing "compare to clj-http"
     (let [{clj-status :status clj-body :body :as resp-clj}
-          (clj-http/get "http://localhost:4347/get" {:proxy-host "127.0.0.1"
+          (clj-http/get "http://127.0.0.1:4347/get" {:proxy-host "127.0.0.1"
                                                      :proxy-port 4348
                                                      :throw-exceptions false
                                                      :proxy-ignore-hosts #{}})
 
           {kit-status :status kit-body :body error :error :as resp-kit}
-          @(http/get "http://localhost:4347/get"
+          @(http/get "http://127.0.0.1:4347/get"
                      {:proxy "http://127.0.0.1:4348"})]
       (is (= clj-status kit-status))
       (is (= clj-body kit-body)))))
 
-(deftest test-proxy
+(deftest proxy-nonexistent
   (testing "test call nonexistent proxy and fail"
-    (let [{:keys [error]} @(http/get "http://localhost:4347/get"
+    (let [{:keys [error]} @(http/get "http://127.0.0.1:4347/get"
                                      {:proxy "http://127.0.0.1:4346"})]
       (is (= (type (java.net.ConnectException.)) (type error)))
       (is (= "Connection refused"
-             (.getMessage ^java.net.ConnectException error)))))
-
+             (.getMessage ^java.net.ConnectException error))))))
+(deftest http-to-http-proxy
   (testing "test call proxy successfully"
-    (let [{:keys [status body]} @(http/get "http://localhost:4347/get"
+    (let [{:keys [status body]} @(http/get "http://127.0.0.1:4347/get"
                                            {:proxy "http://127.0.0.1:4348"})]
+      (is (= 200 status))
+      (is (= "hello world" body)))))
+(deftest https-to-http-proxy
+  (testing "test ssl call proxy successfully"
+    (let [{:keys [status body]} @(http/get "https://127.0.0.1:9898/get"
+                                           {:proxy "http://127.0.0.1:4348"})]
+      (is (= 200 status))
+      (is (= "hello world" body)))))
+(deftest http-to-https-proxy
+  (testing "test call ssl proxy successfully"
+    (let [{:keys [status body]} @(http/get "http://127.0.0.1:4347/get"
+                                           {:proxy "https://127.0.0.1:9899"
+                                            :insecure? true})]
+      (is (= 200 status))
+      (is (= "hello world" body)))))
+(deftest https-to-https-proxy
+  (testing "test ssl call ssl proxy successfully"
+    (let [{:keys [status body]} @(http/get "https://127.0.0.1:9898/get"
+                                           {:proxy "https://127.0.0.1:9899"
+                                            :insecure? true})]
       (is (= 200 status))
       (is (= "hello world" body)))))
 
@@ -78,7 +116,7 @@
 (deftest test-proxy-basic-auth
   (testing "test proxy with successful auth"
     (let [{:keys [status body]}
-          @(http/get "http://localhost:4347/get"
+          @(http/get "http://127.0.0.1:4347/get"
                      {:proxy "http://127.0.0.1:4349"
                       :headers {"Authorization" auth-header-value}})]
       (is (= 200 status))
@@ -86,7 +124,7 @@
 
   (testing "test proxy with unsuccessful auth"
     (let [{:keys [status body]}
-          @(http/get "http://localhost:4347/get"
+          @(http/get "http://127.0.0.1:4347/get"
                      {:proxy "http://127.0.0.1:4349"
                       :headers {"Authorization" bad-auth-header-value}})]
       (is (= 401 status))

--- a/test/org/httpkit/ring_request_proxy.clj
+++ b/test/org/httpkit/ring_request_proxy.clj
@@ -1,0 +1,71 @@
+(ns org.httpkit.ring-request-proxy
+  (:require [clj-http.client :as clj-http]))
+
+;;
+;; code from: https://github.com/FundingCircle/ring-request-proxy
+;; Copyright (c) 2015, Funding Circle
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without modification,
+;; are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its contributors
+;;    may be used to endorse or promote products derived from this software without
+;;    specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+;; ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+;; IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+;; INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+;; BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;; DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+;; LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+;; OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+;; ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+(def ^:private not-found-response {:status 404
+                                   :body "{\"message\":\"Not found\"}"})
+
+(defn- build-url [host path query-string]
+  (println host path query-string)
+  (let [url (.toString (java.net.URL. (java.net.URL. host) path))]
+    (if (not-empty query-string)
+      (str url "?" query-string)
+      url)))
+
+(defn- handle-not-found [request]
+  not-found-response)
+
+(defn- create-proxy-fn [handler opts]
+  (let [identifier-fn (get opts :identifier-fn identity)
+        server-mapping (get opts :host-fn {})
+        insecure (get opts :allow-insecure-ssl false)]
+    (fn [request]
+      (println request)
+      (let [request-key (identifier-fn request)
+            host (server-mapping request-key)
+            stripped-headers (dissoc (:headers request) "content-length")]
+        (if host
+          (select-keys (clj-http/request {:url              (build-url host (:uri request) (:query-string request))
+                                          :method           (:request-method request)
+                                          :body             (:body request)
+                                          :headers          stripped-headers
+                                          :throw-exceptions false
+                                          :as               :stream
+                                          :insecure?        insecure})
+                       [:status :headers :body])
+          (handler request))))))
+
+(defn proxy-request
+  ([opts]
+   (proxy-request handle-not-found opts))
+  ([handler opts]
+   (create-proxy-fn handler opts)))


### PR DESCRIPTION
I need some eyes on it to a) figure out if I actually solved the problem and b) make sure I'm testing this right.

I can't get this to work in mitmproxy so I suspect I missed something.  Either I haven't configured mitmproxy properly, or I've missed something else that needs to be changed.