### PR TITLE
Multipart tweaks

### DIFF
--- a/src/java/org/httpkit/client/MultipartEntity.java
+++ b/src/java/org/httpkit/client/MultipartEntity.java
@@ -14,10 +14,10 @@ import java.util.List;
  *         2014/1/1
  */
 public class MultipartEntity {
-    private String name;
-    private String filename;
-    private Object content;
-    private String contentType;
+    private final String name;
+    private final String filename;
+    private final Object content;
+    private final String contentType;
 
     public MultipartEntity(String name, Object content, String filename, String contentType) {
         this.name = name;

--- a/src/java/org/httpkit/client/MultipartEntity.java
+++ b/src/java/org/httpkit/client/MultipartEntity.java
@@ -66,6 +66,9 @@ public class MultipartEntity {
                 while (((ByteBuffer) e.content).hasRemaining()) {
                     bytes.append(((ByteBuffer) e.content).get()); // copy
                 }
+            } else if (e.content instanceof byte[]) {
+                byte[] contentBytes = (byte[])e.content;
+                bytes.append(contentBytes, contentBytes.length);
             }
             bytes.append(HttpUtils.CR, HttpUtils.LF);
         }

--- a/src/java/org/httpkit/client/MultipartEntity.java
+++ b/src/java/org/httpkit/client/MultipartEntity.java
@@ -17,11 +17,17 @@ public class MultipartEntity {
     private String name;
     private String filename;
     private Object content;
+    private String contentType;
 
-    public MultipartEntity(String name, Object content, String filename) {
+    public MultipartEntity(String name, Object content, String filename, String contentType) {
         this.name = name;
         this.filename = filename;
         this.content = content;
+        this.contentType = contentType;
+    }
+
+    public MultipartEntity(String name, Object content, String filename) {
+        this(name, content, filename, null);
     }
 
     public static String genBoundary(List<MultipartEntity> entities) {
@@ -39,8 +45,10 @@ public class MultipartEntity {
             } else {
                 bytes.append("\"\r\n");
             }
-            if (e.content instanceof File || e.content instanceof InputStream) {
-                // TODO configurable
+
+            if (e.contentType != null) {
+                bytes.append("Content-Type: ").append(e.contentType).append("\r\n\r\n");
+            } else if (e.content instanceof File || e.content instanceof InputStream) {
                 bytes.append("Content-Type: application/octet-stream\r\n\r\n");
             } else {
                 bytes.append("\r\n");

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -71,9 +71,9 @@
             ;; :body ring body: null, String, seq, InputStream, File, ByteBuffer
                  :body      (if form-params (query-string form-params) body))]
     (if multipart
-      (let [entities (into (map (fn [{:keys [name content filename]}]
-                                  (MultipartEntity. name content filename)) multipart)
-                           (map (fn [[k v]] (MultipartEntity. k v nil)) form-params))
+      (let [entities (into (map (fn [{:keys [name content filename content-type]}]
+                                  (MultipartEntity. name content filename content-type)) multipart)
+                           (map (fn [[k v]] (MultipartEntity. k v nil nil)) form-params))
             boundary (MultipartEntity/genBoundary entities)]
         (-> r
             (assoc-in [:headers "Content-Type"]

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -29,7 +29,15 @@
                             {:status code
                              :headers {"location" (str "redirect?total=" total "&n=" (inc n)
                                                        "&code=" code)}}))))
-  (POST "/multipart" [] (fn [req] {:status 200}))
+  (POST "/multipart" [] (fn [req]
+                          (->> req
+                               :params
+                               (reduce-kv
+                                 (fn [acc k v]
+                                   (let [updated (if (map? v) (dissoc v :tempfile :size) v)]
+                                     (assoc acc k updated)))
+                                 {})
+                               pr-str)))
   (PATCH "/patch" [] "hello world")
   (POST "/nested-param" [] (fn [req] (pr-str (:params req))))
   (ANY "/method" [] (fn [req]
@@ -306,9 +314,24 @@
 ))
 
 (deftest test-multipart
-  (is (= 200 (:status @(http/post "http://localhost:4347/multipart"
-                                  {:multipart [{:name "comment" :content "httpkit's project.clj"}
-                                               {:name "file" :content (clojure.java.io/file "project.clj") :filename "project.clj"}]})))))
+  (let [{:keys [status body]} @(http/post "http://localhost:4347/multipart"
+                                          {:multipart [{:name    "comment"
+                                                        :content "httpkit's project.clj"}
+                                                       {:name     "file"
+                                                        :content  (clojure.java.io/file "project.clj")
+                                                        :filename "project.clj"}
+                                                       {:name         "custom-content-type"
+                                                        :content      (clojure.java.io/file "LICENSE.txt")
+                                                        :filename     "LICENSE.txt"
+                                                        :content-type "text/plain"}]})]
+
+    (is (= 200 status))
+    (is (= {:comment             "httpkit's project.clj"
+            :custom-content-type {:content-type "text/plain"
+                                  :filename     "LICENSE.txt"}
+            :file                {:content-type "application/octet-stream"
+                                  :filename     "project.clj"}}
+           (read-string body)))))
 
 (deftest test-coerce-req
   (testing "Headers should be the same regardless of multipart"

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -320,13 +320,16 @@
                                                        {:name     "file"
                                                         :content  (clojure.java.io/file "project.clj")
                                                         :filename "project.clj"}
+                                                       {:name    "bytes"
+                                                        :content (.getBytes "httpkit's project.clj" "UTF-8")}
                                                        {:name         "custom-content-type"
                                                         :content      (clojure.java.io/file "LICENSE.txt")
                                                         :filename     "LICENSE.txt"
                                                         :content-type "text/plain"}]})]
 
     (is (= 200 status))
-    (is (= {:comment             "httpkit's project.clj"
+    (is (= {:bytes               "httpkit's project.clj"
+            :comment             "httpkit's project.clj"
             :custom-content-type {:content-type "text/plain"
                                   :filename     "LICENSE.txt"}
             :file                {:content-type "application/octet-stream"


### PR DESCRIPTION
Allows setting the content-type for each multipart entity.

I also set it to allow byte arrays in a separate commit. This caught me off guard as no errors were ever thrown - just nothing would happen when posting them and it seems to be a pretty common thing people would want to do.