### PR TITLE
Added a getCount method to BytesInputStream

### DIFF
--- a/src/java/org/httpkit/BytesInputStream.java
+++ b/src/java/org/httpkit/BytesInputStream.java
@@ -80,4 +80,8 @@ public class BytesInputStream extends InputStream {
     public void reset() {
         pos = mark;
     }
+
+    public int getCount() {
+        return count;
+    }
 }


### PR DESCRIPTION
At my company, we use the length of inputs to do load estimation on our backend. As of right now, there is no easy way to access the length of a BytesInputStream other than calling toString on it, and parsing out the returned length. 

This PR provides an accessor to count in BytesInputStream. Since it is already exposed in toString, I figured it would not be a problem.

I'm eager to get this in, let me know if there are any changes you'd like! Or, if you'd prefer some alternative approach, let me know and I'll do things your way.