### PR TITLE
Minimal fix to add SNI support to client

### DIFF
--- a/src/java/org/httpkit/HttpMethod.java
+++ b/src/java/org/httpkit/HttpMethod.java
@@ -11,7 +11,7 @@ public enum HttpMethod {
     CONNECT(intern("connect")), PATCH(intern("patch")), PROPFIND(intern("propfind")),
 	PROPPATCH(intern("proppatch")), LOCK(intern("lock")), UNLOCK(intern("unlock")),
 	REPORT(intern("report")), ACL(intern("acl")), MOVE(intern("move")), 
-	COPY(intern("copy"));
+	COPY(intern("copy")), MKCOL(intern("mkcol"));
 
     public final Keyword KEY;
 

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -3,9 +3,12 @@ package org.httpkit.client;
 import org.httpkit.*;
 import org.httpkit.ProtocolException;
 
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import java.io.IOException;
 import java.net.*;
 import java.nio.ByteBuffer;
@@ -13,7 +16,9 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -303,6 +308,13 @@ public class HttpClient implements Runnable {
             }
             if(!engine.getUseClientMode())
                 engine.setUseClientMode(true);
+
+            SSLParameters sslParameters = engine.getSSLParameters();
+            SNIServerName hostName = new SNIHostName(uri.getHost());
+            List<SNIServerName> list = new ArrayList<SNIServerName>();
+            list.add(hostName);
+            sslParameters.setServerNames(list);
+            engine.setSSLParameters(sslParameters);
 
             pending.offer(new HttpsRequest(addr, request, cb, requests, cfg, engine));
         } else {

--- a/test/java/org/httpkit/server/RingHandlerTest.java
+++ b/test/java/org/httpkit/server/RingHandlerTest.java
@@ -27,7 +27,7 @@ public class RingHandlerTest {
 
     @Test
     public void shouldUseExternalThreadPoolForExecution() throws InterruptedException, ProtocolException, LineTooLargeException, RequestTooLargeException {
-        Vector<String> assertionItems = new Vector<>();
+        Vector<String> assertionItems = new Vector<String>();
 
         ExecutorService testWorkerPool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, new ArrayBlockingQueue(2));
         RingHandler ringHandler = new RingHandler(new MockClojureHandler(aDummyResponse()), testWorkerPool);
@@ -40,7 +40,7 @@ public class RingHandlerTest {
 
     @Test
     public void shouldUseInternalThreadPoolForExecution() throws InterruptedException, ProtocolException, LineTooLargeException, RequestTooLargeException {
-        Vector<String> assertionItems = new Vector<>();
+        Vector<String> assertionItems = new Vector<String>();
 
         RingHandler ringHandler = new RingHandler(1, new MockClojureHandler(aDummyResponse()), "some-prefix", 2);
         ringHandler.handle(aDummyRequest(), new MockRespCallback(assertionItems));


### PR DESCRIPTION
Here is an initial effort at resolving #187.  I welcome any feedback, since I
am not very familiar with the http-kit code or the async NIO library.

This works for my particular situation, but there are a couple of caveats:
1. This code is Java 8 only.  If there is a need to support older versions of
   Java, this logic will need to be wrapped.
2. It’s possible that a bad hostname could result in an
   `IllegalArgumentException`.  Is it better for that to be allowed to bubble
   up or should it be swallowed and the SNI support disabled.

Lastly, is this the righ insertion point for adding the SNI support?  I do
not know if there could be any race conditions or shared state that could
result from this.
