### PR TITLE
Fix the 'Close received after close' issue for WS implementation

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -156,11 +156,18 @@ public class HttpServer implements Runnable {
                     atta.decoder.reset();
                     tryWrite(key, WsEncode(WSDecoder.OPCODE_PING, frame.data));
                 } else if (frame instanceof CloseFrame) {
+                    // A snapshot
+                    boolean closed = atta.channel.isClosed();
                     handler.clientClose(atta.channel, ((CloseFrame) frame).getStatus());
                     // close the TCP connection after sent
                     atta.keepalive = false;
                     atta.decoder.reset();
-                    tryWrite(key, WsEncode(WSDecoder.OPCODE_CLOSE, frame.data));
+
+                    // Follow RFC6455 5.5.1 
+                    // Do not send CLOSE frame again if it has been sent.
+                    if (!closed) { 
+                        tryWrite(key, WsEncode(WSDecoder.OPCODE_CLOSE, frame.data));
+                    }
                 }
             } while (buffer.hasRemaining()); // consume all
         } catch (ProtocolException e) {


### PR DESCRIPTION
Today, I met an issue when I was using WebSocket. Whenever the **server** closes a WebSocket channel, my browser reported:

`VM50089:35 WebSocket connection to 'ws://localhost:8081/?topic=6' failed: Close received after close`

After a little digging of the source code and the [RFC section 5.5.1](https://tools.ietf.org/html/rfc6455#section-5.5.1), I found the issue. 
When http-kit server receives a CLOSE frame, it will send back a CLOSE frame, even in the case when the close operation is initiated by the server side. 
So what happened is: 

```
1. Server -> Client: CLOSE + some payload
2. Client -> Server: CLOSE + some payload as response
3. Server -> Client: CLOSE
4. Client reported error.
```

I feel this issue could matter if both client and server implemented the same wrong way. (infinite CLOSE loop). I made a quick-fix. Can you please take a look? Thanks. 