### PR TITLE
Do not respond to unsolicited pong frames

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -153,8 +153,8 @@ public class HttpServer implements Runnable {
                     atta.decoder.reset();
                     tryWrite(key, WsEncode(WSDecoder.OPCODE_PONG, frame.data));
                 } else if (frame instanceof PongFrame) {
+                    // ignored as unsolicited pong frame from client
                     atta.decoder.reset();
-                    tryWrite(key, WsEncode(WSDecoder.OPCODE_PING, frame.data));
                 } else if (frame instanceof CloseFrame) {
                     handler.clientClose(atta.channel, ((CloseFrame) frame).getStatus());
                     // close the TCP connection after sent

--- a/test/java/org/httpkit/ws/WebSocketClient.java
+++ b/test/java/org/httpkit/ws/WebSocketClient.java
@@ -105,16 +105,9 @@ public class WebSocketClient {
         return frame;
     }
 
-    public String pong(String data) throws Exception {
+    public void pong(String data) throws Exception {
         byte[] bytes = data.getBytes();
         ch.write(new PongWebSocketFrame(ChannelBuffers.copiedBuffer(bytes)));
-        WebSocketFrame frame = queue.poll(5, TimeUnit.SECONDS);
-        if (frame instanceof PingWebSocketFrame) {
-            ChannelBuffer d = frame.getBinaryData();
-            return new String(d.array(), 0, d.readableBytes());
-        } else {
-            throw new Exception("pong frame expected, instead of " + frame);
-        }
     }
 
     public String ping(String data) throws Exception {

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -119,7 +119,7 @@
               (is false))))
         (let [d (subs const-string 0 120)]
           (is (= d (.ping client d)))
-          (is (= d (.pong client d))))))
+          (.pong client d))))
     (.close client)))
 
 (deftest test-sent-message-in-body      ; issue #14


### PR DESCRIPTION
Internet Explorer and MS Edge send unsolicited pong frames. Responding to
those with ping frames starts a match.

This fixes #322.