### PR TITLE
[#355] workaround for missing safe key iteration method when stopping

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -379,19 +379,34 @@ public class HttpServer implements Runnable {
 
         // close socket, notify on-close handlers
         if (selector.isOpen()) {
-//            Set<SelectionKey> keys = selector.keys();
-//            SelectionKey[] keys = t.toArray(new SelectionKey[t.size()]);
-            for (SelectionKey k : selector.keys()) {
-                /**
-                 * 1. t.toArray will fill null if given array is larger.
-                 * 2. compute t.size(), then try to fill the array, if in the mean time, another
-                 *    thread close one SelectionKey, will result a NPE
-                 *
-                 * https://github.com/http-kit/http-kit/issues/125
-                 */
-                if (k != null)
-                    closeKey(k, 0); // 0 => close by server
-            }
+	    //            Set<SelectionKey> keys = selector.keys();
+	    //            SelectionKey[] keys = t.toArray(new SelectionKey[t.size()]);
+	    boolean cmex = false;
+	    do {
+		cmex = false;
+		try{
+		    for (SelectionKey k : selector.keys()) {
+			/**
+			 * 1. t.toArray will fill null if given array is larger.
+			 * 2. compute t.size(), then try to fill the array, if in the mean time, another
+			 *    thread close one SelectionKey, will result a NPE
+			 *
+			 * https://github.com/http-kit/http-kit/issues/125
+			 */
+			if (k != null)
+			    closeKey(k, 0); // 0 => close by server
+		    }
+		} catch(java.util.ConcurrentModificationException ex) {
+		    /**
+		     * The iterator will throw a CMEx as soon as we close an open connection. Since there
+		     * seems to be no other way to safely iterate over all keys we just catch the exception
+		     * and try again until we manage to notify all open connections.
+		     *
+		     * https://github.com/http-kit/http-kit/issues/355
+		     */
+		        cmex = true;
+		}		
+	    } while(cmex);
 
             try {
                 selector.close();


### PR DESCRIPTION
As the bug ticket #355 correctly stated, there is no safe way to iterate over `selector.keys()` without any `ConcurrentModificationException`  as soon as we close any client connection. Since we can rely on this behaviour according to the official documentation in https://docs.oracle.com/javase/7/docs/api/java/nio/channels/Selector.html we just retry the closing operation until we successfully closed all connections.