### PR TITLE
Add support for binding client requests to a local address

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -78,19 +78,28 @@ public class HttpClient implements Runnable {
 
     private final AddressFinder addressFinder;
     private final SSLEngineURIConfigurer sslEngineUriConfigurer;
+    private final SocketAddress bindAddress;
 
     public HttpClient() throws IOException {
         this(-1);
     }
 
+
     public HttpClient(long maxConnections, AddressFinder addressFinder, SSLEngineURIConfigurer sslEngineUriConfigurer,
             ContextLogger<String, Throwable> errorLogger,
             EventLogger<String> eventLogger, EventNames eventNames) throws IOException {
+      this(maxConnections, addressFinder, sslEngineUriConfigurer, errorLogger, eventLogger, eventNames, null);
+    }
+
+    public HttpClient(long maxConnections, AddressFinder addressFinder, SSLEngineURIConfigurer sslEngineUriConfigurer,
+            ContextLogger<String, Throwable> errorLogger,
+            EventLogger<String> eventLogger, EventNames eventNames, SocketAddress bindAddress) throws IOException {
         this.addressFinder = addressFinder;
         this.sslEngineUriConfigurer = sslEngineUriConfigurer;
         this.errorLogger = errorLogger;
         this.eventLogger = eventLogger;
         this.eventNames = eventNames;
+        this.bindAddress = bindAddress;
 
         int id = ID.incrementAndGet();
         String name = "client-loop";
@@ -433,6 +442,9 @@ public class HttpClient implements Runnable {
                     SocketChannel ch = SocketChannel.open();
                     ch.setOption(StandardSocketOptions.SO_KEEPALIVE, Boolean.TRUE);
                     ch.setOption(StandardSocketOptions.TCP_NODELAY, Boolean.TRUE);
+                    if (bindAddress != null) {
+                      ch.bind(bindAddress);
+                    }
                     ch.configureBlocking(false);
                     boolean connected = ch.connect(job.addr);
                     job.setConnected(connected);

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -103,13 +103,15 @@
     :ssl-configurer     ; (fn [javax.net.ssl.SSLEngine java.net.URI])
     :error-logger       ; (fn [text ex])
     :event-logger       ; (fn [event-name])
-    :event-names        ; {<http-kit-event-name> <loggable-event-name>}"
+    :event-names        ; {<http-kit-event-name> <loggable-event-name>}
+    :bind-address       ; when present will pass local address to SocketChannel.bind()"
   [{:keys [max-connections
            address-finder
            ssl-configurer
            error-logger
            event-logger
-           event-names]}]
+           event-names
+           bind-address]}]
   (HttpClient.
     (or max-connections -1)
     (if address-finder
@@ -135,7 +137,8 @@
         event-names)     event-names
       :otherwise         (throw (IllegalArgumentException.
                                   (format "Invalid event-names: (%s) %s"
-                                    (class event-names) (pr-str event-names)))))))
+                                    (class event-names) (pr-str event-names)))))
+    bind-address))
 
 (def ^:dynamic ^:private *in-callback* false)
 


### PR DESCRIPTION
On hosts with multiple public ips it can be important to send requests originating from a particular one. This PR adds a bindAddress to HttpClient, which when set, will force the socket to bind to the specified address.

```clojure
(client/get "https://api.ipify.org?format=json"
                {:client
                 (client/make-client {:bind-address (InetSocketAddress. (InetAddress/getByName "192.168.0.165") 0)})}
                (fn [result] (println result)))
```