### PR TITLE
Add duplicated-headers-as-seq? flag to requests

### DIFF
--- a/src/java/org/httpkit/client/Decoder.java
+++ b/src/java/org/httpkit/client/Decoder.java
@@ -78,7 +78,7 @@ public class Decoder {
         }
     }
 
-    public State decode(ByteBuffer buffer) throws LineTooLargeException, ProtocolException,
+    public State decode(ByteBuffer buffer, boolean duplicatedHeadersAsSeq) throws LineTooLargeException, ProtocolException,
             AbortException {
         String line;
         while (buffer.hasRemaining() && state != State.ALL_READ) {
@@ -89,7 +89,7 @@ public class Decoder {
                     }
                     break;
                 case READ_HEADER:
-                    readHeaders(buffer);
+                    readHeaders(buffer, duplicatedHeadersAsSeq);
                     break;
                 case READ_CHUNK_SIZE:
                     line = lineReader.readLine(buffer);
@@ -146,10 +146,10 @@ public class Decoder {
         }
     }
 
-    private void readHeaders(ByteBuffer buffer) throws LineTooLargeException, AbortException, ProtocolException {
+    private void readHeaders(ByteBuffer buffer, boolean duplicatedHeadersAsSeq) throws LineTooLargeException, AbortException, ProtocolException {
         String line = lineReader.readLine(buffer);
         while (line != null && !line.isEmpty()) {
-            HttpUtils.splitAndAddHeader(line, headers);
+            HttpUtils.splitAndAddHeader(line, headers, duplicatedHeadersAsSeq);
             line = lineReader.readLine(buffer);
         }
         if (line == null)

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -198,7 +198,7 @@ public class HttpClient implements Runnable {
             buffer.flip();
             try {
                 State oldState = req.decoder.state;
-                if (req.decoder.decode(buffer) == ALL_READ) {
+                if (req.decoder.decode(buffer,req.cfg.duplicatedHeadersAsSeq) == ALL_READ) {
                     req.finish();
                     if (req.cfg.keepAlive > 0) {
                         // Ensure that the key is added to keepalives exactly once on a state transition. There could be cases where decoder reaches

--- a/src/java/org/httpkit/client/RequestConfig.java
+++ b/src/java/org/httpkit/client/RequestConfig.java
@@ -15,10 +15,11 @@ public class RequestConfig {
     final HttpMethod method;
     final String proxy_url;
     final boolean tunnel;
+    final boolean duplicatedHeadersAsSeq;
 
     public RequestConfig(HttpMethod method, Map<String, Object> headers, Object body,
                          int connTimeoutMs, int idleTimeoutMs, int keepAliveMs,
-                         String proxy_url, boolean tunnel) {
+                         String proxy_url, boolean tunnel, boolean duplicatedHeadersAsSeq) {
         this.connTimeout = connTimeoutMs;
         this.idleTimeout = idleTimeoutMs;
         this.keepAlive = keepAliveMs;
@@ -27,9 +28,10 @@ public class RequestConfig {
         this.method = method;
         this.proxy_url = proxy_url;
         this.tunnel = tunnel;
+        this.duplicatedHeadersAsSeq = duplicatedHeadersAsSeq;
     }
 
     public RequestConfig() { // for easy test only
-        this(HttpMethod.GET, null, null, 40000, 40000, -1, null, false);
+        this(HttpMethod.GET, null, null, 40000, 40000, -1, null, false, false);
     }
 }

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -149,7 +149,7 @@ public class HttpDecoder {
             expect != null && CONTINUE.equalsIgnoreCase(expect));
     }
 
-    public HttpRequest decode(ByteBuffer buffer) throws LineTooLargeException,
+    public HttpRequest decode(ByteBuffer buffer, boolean duplicatedHeadersAsSeq) throws LineTooLargeException,
             ProtocolException, RequestTooLargeException {
         String line;
         while (buffer.hasRemaining()) {
@@ -183,7 +183,7 @@ public class HttpDecoder {
                     }
                     break;
                 case READ_HEADER:
-                    readHeaders(buffer);
+                    readHeaders(buffer, duplicatedHeadersAsSeq);
                     break;
                 case READ_CHUNK_SIZE:
                     line = lineReader.readLine(buffer);
@@ -248,7 +248,7 @@ public class HttpDecoder {
         readCount += toRead;
     }
 
-    private void readHeaders(ByteBuffer buffer) throws LineTooLargeException,
+    private void readHeaders(ByteBuffer buffer, boolean duplicatedHeadersAsSeq) throws LineTooLargeException,
             RequestTooLargeException, ProtocolException {
         if (proxyProtocolOption == ProxyProtocolOption.OPTIONAL
             || proxyProtocolOption == ProxyProtocolOption.ENABLED) {
@@ -258,7 +258,7 @@ public class HttpDecoder {
         }
         String line = lineReader.readLine(buffer);
         while (line != null && !line.isEmpty()) {
-            HttpUtils.splitAndAddHeader(line, headers);
+            HttpUtils.splitAndAddHeader(line, headers, duplicatedHeadersAsSeq);
             line = lineReader.readLine(buffer);
         }
 

--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -379,34 +379,34 @@ public class HttpServer implements Runnable {
 
         // close socket, notify on-close handlers
         if (selector.isOpen()) {
-      //            Set<SelectionKey> keys = selector.keys();
-      //            SelectionKey[] keys = t.toArray(new SelectionKey[t.size()]);
-      boolean cmex = false;
-      do {
-    cmex = false;
-    try{
-        for (SelectionKey k : selector.keys()) {
-      /**
-       * 1. t.toArray will fill null if given array is larger.
-       * 2. compute t.size(), then try to fill the array, if in the mean time, another
-       *    thread close one SelectionKey, will result a NPE
-       *
-       * https://github.com/http-kit/http-kit/issues/125
-       */
-      if (k != null)
-          closeKey(k, 0); // 0 => close by server
-        }
-    } catch(java.util.ConcurrentModificationException ex) {
-        /**
-         * The iterator will throw a CMEx as soon as we close an open connection. Since there
-         * seems to be no other way to safely iterate over all keys we just catch the exception
-         * and try again until we manage to notify all open connections.
-         *
-         * https://github.com/http-kit/http-kit/issues/355
-         */
-            cmex = true;
-    }
-      } while(cmex);
+           //            Set<SelectionKey> keys = selector.keys();
+           //            SelectionKey[] keys = t.toArray(new SelectionKey[t.size()]);
+           boolean cmex = false;
+           do {
+               cmex = false;
+               try{
+                   for (SelectionKey k : selector.keys()) {
+                       /**
+                        * 1. t.toArray will fill null if given array is larger.
+                        * 2. compute t.size(), then try to fill the array, if in the mean time, another
+                        *    thread close one SelectionKey, will result a NPE
+                        *
+                        * https://github.com/http-kit/http-kit/issues/125
+                        */
+                       if (k != null)
+                           closeKey(k, 0); // 0 => close by server
+                   }
+               } catch(java.util.ConcurrentModificationException ex) {
+                   /**
+                    * The iterator will throw a CMEx as soon as we close an open connection. Since there
+                    * seems to be no other way to safely iterate over all keys we just catch the exception
+                    * and try again until we manage to notify all open connections.
+                    *
+                    * https://github.com/http-kit/http-kit/issues/355
+                    */
+                        cmex = true;
+               }
+           } while(cmex);
 
             try {
                 selector.close();

--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -151,7 +151,7 @@ public class HttpServer implements Runnable {
             boolean sentContinue = false;
             do {
                 AsyncChannel channel = atta.channel;
-                HttpRequest request = atta.decoder.decode(buffer);
+                HttpRequest request = atta.decoder.decode(buffer,false);
                 if (request != null) {
                     channel.reset(request);
                     if (request.isWebSocket) {
@@ -204,9 +204,9 @@ public class HttpServer implements Runnable {
                     atta.keepalive = false;
                     atta.decoder.reset();
 
-                    // Follow RFC6455 5.5.1 
+                    // Follow RFC6455 5.5.1
                     // Do not send CLOSE frame again if it has been sent.
-                    if (!closed) { 
+                    if (!closed) {
                         tryWrite(key, WsEncode(WSDecoder.OPCODE_CLOSE, frame.data));
                     }
                 }
@@ -379,34 +379,34 @@ public class HttpServer implements Runnable {
 
         // close socket, notify on-close handlers
         if (selector.isOpen()) {
-	    //            Set<SelectionKey> keys = selector.keys();
-	    //            SelectionKey[] keys = t.toArray(new SelectionKey[t.size()]);
-	    boolean cmex = false;
-	    do {
-		cmex = false;
-		try{
-		    for (SelectionKey k : selector.keys()) {
-			/**
-			 * 1. t.toArray will fill null if given array is larger.
-			 * 2. compute t.size(), then try to fill the array, if in the mean time, another
-			 *    thread close one SelectionKey, will result a NPE
-			 *
-			 * https://github.com/http-kit/http-kit/issues/125
-			 */
-			if (k != null)
-			    closeKey(k, 0); // 0 => close by server
-		    }
-		} catch(java.util.ConcurrentModificationException ex) {
-		    /**
-		     * The iterator will throw a CMEx as soon as we close an open connection. Since there
-		     * seems to be no other way to safely iterate over all keys we just catch the exception
-		     * and try again until we manage to notify all open connections.
-		     *
-		     * https://github.com/http-kit/http-kit/issues/355
-		     */
-		        cmex = true;
-		}		
-	    } while(cmex);
+      //            Set<SelectionKey> keys = selector.keys();
+      //            SelectionKey[] keys = t.toArray(new SelectionKey[t.size()]);
+      boolean cmex = false;
+      do {
+    cmex = false;
+    try{
+        for (SelectionKey k : selector.keys()) {
+      /**
+       * 1. t.toArray will fill null if given array is larger.
+       * 2. compute t.size(), then try to fill the array, if in the mean time, another
+       *    thread close one SelectionKey, will result a NPE
+       *
+       * https://github.com/http-kit/http-kit/issues/125
+       */
+      if (k != null)
+          closeKey(k, 0); // 0 => close by server
+        }
+    } catch(java.util.ConcurrentModificationException ex) {
+        /**
+         * The iterator will throw a CMEx as soon as we close an open connection. Since there
+         * seems to be no other way to safely iterate over all keys we just catch the exception
+         * and try again until we manage to notify all open connections.
+         *
+         * https://github.com/http-kit/http-kit/issues/355
+         */
+            cmex = true;
+    }
+      } while(cmex);
 
             try {
                 selector.close();

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -230,14 +230,14 @@
                               change-to-get (and (not allow-unsafe-redirect-methods)
                                                  (#{301 302 303} status))]
                           (request (assoc opts ; follow 301 and 302 redirect
-                                          :url location
-                                          :response response
-                                          :query-params (if change-to-get nil (:query-params opts))
-                                          :form-params (if change-to-get nil (:form-params opts))
-                                          :method (if change-to-get
-                                                    :get ;; change to :GET
-                                                    (:method opts))  ;; do not change
-                                          :trace-redirects (conj trace-redirects url))
+                                     :url location
+                                     :response response
+                                     :query-params (if change-to-get nil (:query-params opts))
+                                     :form-params (if change-to-get nil (:form-params opts))
+                                     :method (if change-to-get
+                                               :get ;; change to :GET
+                                               (:method opts))  ;; do not change
+                                     :trace-redirects (conj trace-redirects url))
                                    callback))
                         (deliver-resp {:opts (dissoc opts :response)
                                        :error (Exception. (str "too many redirects: "

--- a/test/java/org/httpkit/client/HttpClientDecoderTest.java
+++ b/test/java/org/httpkit/client/HttpClientDecoderTest.java
@@ -41,7 +41,7 @@ public class HttpClientDecoderTest {
         }, HttpMethod.GET);
 
         ByteBuffer buffer = ByteBuffer.wrap(Utils.readAll("beta_shield_chunked"));
-        State s = decoder.decode(buffer);
+        State s = decoder.decode(buffer, false);
         Assert.assertEquals("state should be ALL_READ", s, State.ALL_READ);
     }
 
@@ -73,11 +73,11 @@ public class HttpClientDecoderTest {
         List<byte[]> chunks = Utils.readAll("chunk_split_1", "chunk_split_2", "chunk_split_3");
         int i = 0;
         while (i < chunks.size() - 1) {
-            State state = decoder.decode(ByteBuffer.wrap(chunks.get(i)));
+            State state = decoder.decode(ByteBuffer.wrap(chunks.get(i)), false);
             Assert.assertNotSame(State.ALL_READ, state);
             i++;
         }
-        State state = decoder.decode(ByteBuffer.wrap(chunks.get(i)));
+        State state = decoder.decode(ByteBuffer.wrap(chunks.get(i)), false);
         Assert.assertEquals(State.ALL_READ, state);
     }
 }

--- a/test/java/org/httpkit/client/HttpsClientTest.java
+++ b/test/java/org/httpkit/client/HttpsClientTest.java
@@ -39,7 +39,7 @@ public class HttpsClientTest {
         for (String url : urls) {
             final CountDownLatch cd = new CountDownLatch(1);
             SSLEngine engine = SslContextFactory.getClientContext().createSSLEngine();
-            RequestConfig cfg = new RequestConfig(HttpMethod.POST, null, null, 40000, 40000, -1, null, false);
+            RequestConfig cfg = new RequestConfig(HttpMethod.POST, null, null, 40000, 40000, -1, null, false, false);
             TreeMap<String, Object> headers = new TreeMap<String, Object>();
             for (int i = 0; i < 33; i++) {
                 headers.put("X-long-header" + i, AGENT + AGENT + AGENT + AGENT);

--- a/test/java/org/httpkit/server/RingHandlerTest.java
+++ b/test/java/org/httpkit/server/RingHandlerTest.java
@@ -72,7 +72,7 @@ public class RingHandlerTest {
     private HttpRequest asHttpRequest(String... requestLines) throws ProtocolException, LineTooLargeException, RequestTooLargeException {
         httpDecoder.reset();
         String joinedRequest = String.join("\n", requestLines);
-        return httpDecoder.decode(ByteBuffer.wrap((joinedRequest + "\n\n").getBytes()));
+        return httpDecoder.decode(ByteBuffer.wrap((joinedRequest + "\n\n").getBytes()), false);
     }
 
     private IPersistentMap aDummyResponse() {

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -352,6 +352,13 @@
     (is (= 2 (count (split (-> resp :headers :x-method) #","))))
     (is (= 200 (:status resp2)))))
 
+(deftest test-header-multiple-values-as-seq
+  (let [resp @(http/get "http://localhost:4347/multi-header" {:headers {"foo" ["bar" "baz"], "eggplant" "quux"}
+                                                              :duplicated-headers-as-seq? true})]
+    (is (= 200 (:status resp)))
+    (is (= 3 (count (-> resp :headers :x-method2))))
+    (is (= 2 (count (-> resp :headers :x-method))))))
+
 (deftest test-headers-stringified
   (doseq [[sent expected] [["test" "test"]
                            [0 "0"]
@@ -372,7 +379,7 @@
                    (onBodyReceived [_ buf n]      (swap! out conj [:body (into [] (take n buf))]))
                    (onCompleted [_]               (swap! out conj [:completed]))
                    (onThrowable [_ t]             (swap! out conj [:error t])))]
-    (.decode (Decoder. listener method) buffer)
+    (.decode (Decoder. listener method) buffer false)
     @out))
 
 (deftest test-decode-partial-status-line


### PR DESCRIPTION
Add an option to requests which forces duplicated keys in the response to be returned as a seq of strings instead of as a single, comma delimited string.  

I am using http-kit to build a reverse proxy for some services.  Some of the requests to those services contain headers with multiple values and http-kit currently concatenates all such multi-headers into a single, comma delimited value.  For example, there can be multiple 'set-cookie' headers in a request and the services are not happy when those headers are merged into one comma separated value.  I can (and I currently do) split those headers up again and turn them into multiple headers, but that seems a bit messier and less effiecient than necessary.  It also requires me to know which headers I need to check and split if necessary and there don't seem to be any real standards around which headers might be duplicated.  So having the capability to optionally leave multiple headers as a seq of headers makes building a reverse proxy easier and more robust.