### PR TITLE
support byte[] responses

### DIFF
--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -99,6 +99,8 @@ public class HttpUtils {
         } else if (body instanceof InputStream) {
             DynamicBytes b = readAll((InputStream) body);
             return ByteBuffer.wrap(b.get(), 0, b.length());
+        } else if (body instanceof byte[]) {
+            return ByteBuffer.wrap((byte[]) body);
         } else if (body instanceof File) {
             // serving file is better be done by Nginx
             return readAll((File) body);


### PR DESCRIPTION
Why? With libs like [jsonista](https://github.com/metosin/jsonista), the fastest way to serialize Clojure/EDN data is to write it directly into `byte[]`. Aleph and the next version Immutant support this already.

Ported the top3 Clojure Entries in [techempower web benchmarks](https://www.techempower.com/benchmarks/) to Jsonista + `byte[]`: 

<img width="1008" alt="screen shot 2018-06-17 at 15 45 07" src="https://user-images.githubusercontent.com/567532/41507977-b16c0680-7245-11e8-8f10-6fe086cff231.png">
