### PR TITLE
Support java 11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
      [junit/junit                     "4.12"]
      [org.clojure/tools.logging      "0.4.0"]
      [ch.qos.logback/logback-classic "1.2.3"]
-     [clj-http                       "2.1.0"] ; TODO Update (breaking?)
+     [clj-http                       "3.9.1"]
      [io.netty/netty           "3.6.5.Final"] ; TODO Update (breaking)
      [org.clojure/data.json          "0.2.6"]
      [http.async.client              "0.5.2"] ; TODO Update (breaking)

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -16,6 +16,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 import java.security.NoSuchAlgorithmException;
+import java.security.KeyManagementException;
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.Set;
@@ -36,8 +37,9 @@ public class HttpClient implements Runnable {
 
     static {
         try {
-            DEFAULT_CONTEXT = SSLContext.getDefault();
-        } catch (NoSuchAlgorithmException e) {
+            DEFAULT_CONTEXT = SSLContext.getInstance("TLS");
+            DEFAULT_CONTEXT.init(null, TrustManagerFactory.getTrustManagers() ,null);
+        } catch (Exception e) {
             throw new Error("Failed to initialize SSLContext", e);
         }
     }

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -70,8 +70,8 @@ public class HttpClient implements Runnable {
     }
 
     public static interface SSLEngineURIConfigurer {
-        public static final SSLEngineURIConfigurer NOP = new SSLEngineURIConfigurer() {
-            public void configure(SSLEngine sslEngine, URI uri) { /* do nothing */ }
+        public static final SSLEngineURIConfigurer CLIENT_MODE = new SSLEngineURIConfigurer() {
+            public void configure(SSLEngine sslEngine, URI uri) { sslEngine.setUseClientMode(true); }
         };
         void configure(SSLEngine sslEngine, URI uri);
     }
@@ -105,7 +105,7 @@ public class HttpClient implements Runnable {
     }
 
     public HttpClient(long maxConnections) throws IOException {
-        this(maxConnections, AddressFinder.DEFAULT, SSLEngineURIConfigurer.NOP,
+        this(maxConnections, AddressFinder.DEFAULT, SSLEngineURIConfigurer.CLIENT_MODE,
                 ContextLogger.ERROR_PRINTER, EventLogger.NOP, EventNames.DEFAULT);
     }
 

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -119,7 +119,7 @@
     (if ssl-configurer
       (reify HttpClient$SSLEngineURIConfigurer
         (configure [this ssl-engine uri] (ssl-configurer ssl-engine uri)))
-      HttpClient$SSLEngineURIConfigurer/NOP)
+      HttpClient$SSLEngineURIConfigurer/CLIENT_MODE)
     (if error-logger
       (reify ContextLogger
         (log [this message error] (error-logger message error)))

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -292,6 +292,14 @@
                                      (assoc (rand-keep-alive) :insecure? true))
                           :body count)))))))
 
+(deftest test-misc-https-certs
+  ;; Check to make sure an https connection works using the default trust store.
+  (is (contains? @(http/get "https://status.github.com/api/status.json") :status))
+  (is (contains? @(http/get "https://google.com") :status))
+  (is (contains? @(http/get "https://apple.com") :status))
+  (is (contains? @(http/get "https://microsoft.com") :status))
+  (is (contains? @(http/get "https://letsencrypt.org") :status)))
+
 ;; https://github.com/http-kit/http-kit/issues/54
 (deftest test-nested-param
   (let [url "http://localhost:4347/nested-param"

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -297,11 +297,19 @@
   (let [url "http://localhost:4347/nested-param"
         params {:card {:number "4242424242424242" :exp_month "12"}}]
     (is (= params (read-string (:body @(http/post url {:form-params params})))))
+
+    (is (= params (read-string (:body @(http/post
+                                        url
+                                        {:query-params {"card[number]" 4242424242424242
+                                                       "card[exp_month]" 12}})))))
+    (is (= params (read-string (:body (clj-http/post url {:query-params params})))))
+
+    ;; clj-http doesn't actually process these as nested params anymore. Leaving
+    ;; to maintain backward compatibility
     (is (= params (read-string (:body @(http/post
                                         url
                                         {:form-params {"card[number]" 4242424242424242
-                                                       "card[exp_month]" 12}})))))
-    (is (= params (read-string (:body (clj-http/post url {:form-params params})))))))
+                                                       "card[exp_month]" 12}})))))))
 
 (deftest test-redirect
   (let [url "http://localhost:4347/redirect?total=5&n=0"]


### PR DESCRIPTION
Let me know if you want separate pull requests, or squashed commits, or whatever. I just thought it'd be easier to understand what's going on with 3 commits in one PR.

I needed to make the following three changes in order for http-kit to work in Java 11.

## Update cli-http

I suspect cli-http needed to be updated for similar reasons to the following two sections.

cli-http's nested params feature changed a little bit. I updated the test to make sure http-kit matches cli-http for `:query-params` but left them different for `:form-params`.

## Set SSLEngine.useClientMode(true)

I was getting the following exception without setting SSLEngine.setUseClientMode:
```
java.lang.IllegalStateException: Client/Server mode has not yet been set.
	at java.base/sun.security.ssl.SSLEngineImpl.beginHandshake(SSLEngineImpl.java:98)
	at org.httpkit.client.HttpClient.finishConnect(HttpClient.java:395)
	at org.httpkit.client.HttpClient.run(HttpClient.java:472)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

## Configure the TrustManagers on the SSL default context.
Something about SSLContext.getDefault() was causing verify errors when connecting to google.com.

