### PR TITLE
Make `query-string` public

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -44,7 +44,7 @@
                d))
            params))
 
-(defn- query-string
+(defn query-string
   "Returns URL-encoded query string for given params map."
   [m]
   (let [m (nested-param m)


### PR DESCRIPTION
The `query-string` fn is useful to library clients, so make it publicly accessible.