### PR TITLE
PR to address #318

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject juji/http-kit "2.4.0-alpha2"
+(defproject http-kit "2.4.0-alpha2"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit "2.4.0-alpha2"
+(defproject juji/http-kit "2.4.0-alpha2"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -161,7 +161,7 @@
 (def accept "DEPRECATED for `sec-websocket-accept" sec-websocket-accept)
 
 (defn websocket-handshake-check
-  "Returns true iff received a valid WebSocket request."
+  "Returns sec-ws-accept iff received a valid WebSocket request."
   [^AsyncChannel ch ring-req]
   (when-let [sec-ws-key (get-in ring-req [:headers "sec-websocket-key"])]
     (when-let [sec-ws-accept (try (sec-websocket-accept sec-ws-key)
@@ -169,12 +169,12 @@
       sec-ws-accept)))
 
 (defn send-websocket-handshake!
-  "Upgraded to  WebSocket request."
+  "Upgrade to WebSocket connection."
   [^AsyncChannel ch ^String sec-ws-accept]
   (.sendHandshake ch 
-                  {"Upgrade" "websocket"
-                   "Connection" "Upgrade"
-                   "Sec-WebSocket-Accept" sec-ws-accept}))
+    {"Upgrade" "websocket" 
+     "Connection" "Upgrade" 
+     "Sec-WebSocket-Accept" sec-ws-accept}))
 
 ;; (defn websocket-req? [ring-req] (:websocket?    ring-req))
 ;; (defn async-channel  [ring-req] (:async-channel ring-req))
@@ -206,8 +206,7 @@
       (with-channel request ch
         (println \"New WebSocket channel:\" ch)
         (on-receive ch (fn [msg]    (println \"on-receive:\" msg)))
-        (on-close   ch (fn [status] (println \"on-close:\" status)))
-        (send! ch \"First chat message!\"))))
+        (on-close   ch (fn [status] (println \"on-close:\" status))))))
 
   Channel API (see relevant docstrings for more info):
     (open? [ch])

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -24,15 +24,6 @@
                           (println e)
                           (send! con msg)))))))
 
-;; HY: removed to address #46
-#_(defn ws-handler-sent-on-connect [req]
-  (with-channel req con
-    (send! con "hello") ;; should sendable when on-connet
-    (send! con "world")
-    (on-receive con (fn [mesg]
-                      ;; only :body is picked
-                      (send! con {:body mesg}))))) ; echo back
-
 (defn ws-handler-async-client [req] ;; test with http.async.client, echo back
   (with-channel req con
     (on-receive con (fn [mesg]
@@ -78,7 +69,6 @@
 
 (defroutes test-routes
   (GET "/ws" [] ws-handler)
-  ;(GET "/sent-on-connect" [] ws-handler-sent-on-connect)
   (GET "/echo" [] ws-handler-async-client)
   (GET "/http-async-client" [] ws-handler-async-client)
   (GET "/binary" [] binary-ws-handler)
@@ -132,16 +122,6 @@
   (let [client (WebSocketClient. "ws://localhost:4348/ping-pong")]
     (.ping client "TEST")
     (is (= "ECHO: TEST" (.getMessage client)))
-    (.close client)))
-
-#_(deftest test-sent-message-in-body      ; issue #14
-  (let [client (WebSocketClient. "ws://localhost:4348/sent-on-connect")]
-    (is (= "hello" (.getMessage client)))
-    (is (= "world" (.getMessage client)))
-    (doseq [idx (range 0 3)]
-      (let [mesg (str "message#" idx)]
-        (.sendMessage client mesg)
-        (is (= mesg (.getMessage client))))) ;; echo expected
     (.close client)))
 
 (deftest test-tcp-segmented-frame-does-right  ; issue #47

--- a/test/org/httpkit/ws_test.clj
+++ b/test/org/httpkit/ws_test.clj
@@ -24,7 +24,8 @@
                           (println e)
                           (send! con msg)))))))
 
-(defn ws-handler-sent-on-connect [req]
+;; HY: removed to address #46
+#_(defn ws-handler-sent-on-connect [req]
   (with-channel req con
     (send! con "hello") ;; should sendable when on-connet
     (send! con "world")
@@ -77,7 +78,7 @@
 
 (defroutes test-routes
   (GET "/ws" [] ws-handler)
-  (GET "/sent-on-connect" [] ws-handler-sent-on-connect)
+  ;(GET "/sent-on-connect" [] ws-handler-sent-on-connect)
   (GET "/echo" [] ws-handler-async-client)
   (GET "/http-async-client" [] ws-handler-async-client)
   (GET "/binary" [] binary-ws-handler)
@@ -133,7 +134,7 @@
     (is (= "ECHO: TEST" (.getMessage client)))
     (.close client)))
 
-(deftest test-sent-message-in-body      ; issue #14
+#_(deftest test-sent-message-in-body      ; issue #14
   (let [client (WebSocketClient. "ws://localhost:4348/sent-on-connect")]
     (is (= "hello" (.getMessage client)))
     (is (= "world" (.getMessage client)))


### PR DESCRIPTION
As explained in my comment to #318, this PR fixes the common problem of not receiving the first message from the client after a WebSocket connection is established, due to the fact that the server sends out the handshake before evaluating `with-channel` body, which often is used to setup the hooks for receiving client messages.

This solution does introduce a breaking change. It will disable the feature requested in #14, which is to send server side messages even before the WebSocket connection is established. The proper way to handle #14 is to create a queue to save these pre-connection messages and then push them out once the connection is open, as was done in an early version of this software, but that code was latter removed to simplify logic. 

I don't believe the functionality in #14 is needed. Even if some one is using that, I don't think it is hard to work around #14, whereas #318 is very hard to work around, because we often do not have control of the behavior of our clients, but we do have control of the server. 