### PR TITLE
#400 - add option for no decompressing or coercion whatsoever

### DIFF
--- a/src/java/org/httpkit/client/RespListener.java
+++ b/src/java/org/httpkit/client/RespListener.java
@@ -127,6 +127,10 @@ public class RespListener implements IRespListener {
             return;
         }
         try {
+            if (coercion == 0) {
+                pool.submit(new Handler(handler, status.getCode(), headers, body));
+                return;
+            }
             DynamicBytes bytes = unzipBody();
             // 1=> auto, 2=>text, 3=>stream, 4=>byte-array
             if (coercion == 2 || (coercion == 1 && isText())) {

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -290,6 +290,16 @@ public class AsyncChannel {
     static Keyword K_WS_1001 = Keyword.intern("going-away");
     static Keyword K_WS_1002 = Keyword.intern("protocol-error");
     static Keyword K_WS_1003 = Keyword.intern("unsupported");
+    // 1004 is Reserved
+    static Keyword K_WS_1005 = Keyword.intern("no-status-received");
+    static Keyword K_WS_1006 = Keyword.intern("abnormal");
+    static Keyword K_WS_1007 = Keyword.intern("invalid-payload-data");
+    static Keyword K_WS_1008 = Keyword.intern("policy-violation");
+    static Keyword K_WS_1009 = Keyword.intern("message-too-big");
+    static Keyword K_WS_1010 = Keyword.intern("mandatory-extension");
+    static Keyword K_WS_1011 = Keyword.intern("internal-server-error");
+    // 1012 - 1014 are undefined
+    static Keyword K_WS_1015 = Keyword.intern("tls-handshake");
     static Keyword K_UNKNOWN = Keyword.intern("unknown");
 
     private static Keyword readable(int status) {
@@ -306,6 +316,22 @@ public class AsyncChannel {
                 return K_WS_1002;
             case 1003:
                 return K_WS_1003;
+            case 1005:
+                return K_WS_1005;
+            case 1006:
+                return K_WS_1006;
+            case 1007:
+                return K_WS_1007;
+            case 1008:
+                return K_WS_1008;
+            case 1009:
+                return K_WS_1009;
+            case 1010:
+                return K_WS_1010;
+            case 1011:
+                return K_WS_1011;
+            case 1015:
+                return K_WS_1015;
             default:
                 return K_UNKNOWN;
         }

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -189,6 +189,8 @@
   (request {:url \"http://site.com/string.txt\" :as :text})
   ;; Try to automatically coerce the output based on the content-type header, currently supports :text :stream, (with automatic charset detection)
   (request {:url \"http://site.com/string.txt\" :as :auto})
+  ;; return the body as is with no unzipping or coercion whatsoever. returns as org.httpkit.DynamicBytes
+  (request {:url \"http://site.com/favicon.ico\" :as :none})
 
   Request options:
     :url :method :headers :timeout :connect-timeout :idle-timeout :query-params
@@ -251,8 +253,9 @@
                   (onThrowable [this t]
                     (deliver-resp {:opts opts :error t})))
         listener (RespListener. handler filter worker-pool
-                                ;; only the 4 support now
-                                (case as :auto 1 :text 2 :stream 3 :byte-array 4))
+                                ;; 0 will return as DynamicBytes - i.e. you will need to handle unzip yourself
+                                ;; otherwise, there are 4 coercions supported for now
+                                (case as :none 0 :auto 1 :text 2 :stream 3 :byte-array 4))
         effective-proxy-url (if proxy-host (str proxy-host ":" proxy-port) proxy-url)
         connect-timeout (or timeout connect-timeout)
         idle-timeout    (or timeout idle-timeout)

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -13,7 +13,7 @@
             [clojure.java.io :as io]
             [clj-http.client :as clj-http])
   (:import java.nio.ByteBuffer
-           [org.httpkit HttpMethod HttpStatus HttpVersion]
+           [org.httpkit HttpMethod HttpStatus HttpVersion DynamicBytes]
            [org.httpkit.client Decoder IRespListener]))
 
 (defroutes test-routes
@@ -60,7 +60,8 @@
   (PUT "/body" [] (fn [req] {:body (:body req)
                              :status 200
                              :headers {"content-type" "text/plain"}}))
-  (GET "/test-header" [] (fn [{:keys [headers]}] (str (get headers "test-header")))))
+  (GET "/test-header" [] (fn [{:keys [headers]}] (str (get headers "test-header"))))
+  (GET "/zip" [] (fn [req] {:body "hello world"})))
 
 (use-fixtures :once
   (fn [f]
@@ -475,6 +476,9 @@
       (let [{:keys [error]} (bad-callback loop-depth true)]
         (is (= nil error)))
       (println "Skipping disabled-deadlock-guard test due to low CPU count."))))
+
+(deftest zip
+  (is (instance? DynamicBytes (:body @(http/get "http://localhost:4347/zip" {:as :none})))))
 
 ;; @(http/get "http://127.0.0.1:4348" {:headers {"Connection" "Close"}})
 


### PR DESCRIPTION
":as" key which is used for coercion has a new option called ":none" which will immediately return the body of the response as DynamicBytes which is basically just a byte array.

Got this failure in `rake junit`:
```
There was 1 failure:
1) testDecodeChunkSplits(org.httpkit.client.HttpClientDecoderTest)
java.lang.NullPointerException
```
but it seems to be happening in master as well so I don't think I caused any regression.
