### PR TITLE
Fix SSLEngine configuration for Java 11

### DIFF
--- a/src/java/org/httpkit/client/ClientSslEngineFactory.java
+++ b/src/java/org/httpkit/client/ClientSslEngineFactory.java
@@ -8,7 +8,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 
-public class SslContextFactory {
+public class ClientSslEngineFactory {
 
     private static final String PROTOCOL = "TLS";
     private static final SSLContext CLIENT_CONTEXT;
@@ -28,12 +28,10 @@ public class SslContextFactory {
         CLIENT_CONTEXT = clientContext;
     }
 
-    public static SSLContext getClientContext() {
-        return CLIENT_CONTEXT;
-    }
-
     public static SSLEngine trustAnybody() {
-        return CLIENT_CONTEXT.createSSLEngine();
+        SSLEngine engine = CLIENT_CONTEXT.createSSLEngine();
+        engine.setUseClientMode(true);
+        return engine;
     }
 }
 

--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -72,8 +72,8 @@ public class HttpClient implements Runnable {
     }
 
     public static interface SSLEngineURIConfigurer {
-        public static final SSLEngineURIConfigurer CLIENT_MODE = new SSLEngineURIConfigurer() {
-            public void configure(SSLEngine sslEngine, URI uri) { sslEngine.setUseClientMode(true); }
+        public static final SSLEngineURIConfigurer NOP = new SSLEngineURIConfigurer() {
+            public void configure(SSLEngine sslEngine, URI uri) { /* do nothing */ }
         };
         void configure(SSLEngine sslEngine, URI uri);
     }
@@ -116,7 +116,7 @@ public class HttpClient implements Runnable {
     }
 
     public HttpClient(long maxConnections) throws IOException {
-        this(maxConnections, AddressFinder.DEFAULT, SSLEngineURIConfigurer.CLIENT_MODE,
+        this(maxConnections, AddressFinder.DEFAULT, SSLEngineURIConfigurer.NOP,
                 ContextLogger.ERROR_PRINTER, EventLogger.NOP, EventNames.DEFAULT);
     }
 
@@ -356,6 +356,7 @@ public class HttpClient implements Runnable {
             || (proxyUri != null && "https".equals(proxyUri.getScheme()))) {
             if (engine == null) {
                 engine = DEFAULT_CONTEXT.createSSLEngine();
+                engine.setUseClientMode(true);
             }
             if(!engine.getUseClientMode())
                 engine.setUseClientMode(true);

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -290,6 +290,16 @@ public class AsyncChannel {
     static Keyword K_WS_1001 = Keyword.intern("going-away");
     static Keyword K_WS_1002 = Keyword.intern("protocol-error");
     static Keyword K_WS_1003 = Keyword.intern("unsupported");
+    // 1004 is Reserved
+    static Keyword K_WS_1005 = Keyword.intern("no-status-received");
+    static Keyword K_WS_1006 = Keyword.intern("abnormal");
+    static Keyword K_WS_1007 = Keyword.intern("invalid-payload-data");
+    static Keyword K_WS_1008 = Keyword.intern("policy-violation");
+    static Keyword K_WS_1009 = Keyword.intern("message-too-big");
+    static Keyword K_WS_1010 = Keyword.intern("mandatory-extension");
+    static Keyword K_WS_1011 = Keyword.intern("internal-server-error");
+    // 1012 - 1014 are undefined
+    static Keyword K_WS_1015 = Keyword.intern("tls-handshake");
     static Keyword K_UNKNOWN = Keyword.intern("unknown");
 
     private static Keyword readable(int status) {
@@ -306,6 +316,22 @@ public class AsyncChannel {
                 return K_WS_1002;
             case 1003:
                 return K_WS_1003;
+            case 1005:
+                return K_WS_1005;
+            case 1006:
+                return K_WS_1006;
+            case 1007:
+                return K_WS_1007;
+            case 1008:
+                return K_WS_1008;
+            case 1009:
+                return K_WS_1009;
+            case 1010:
+                return K_WS_1010;
+            case 1011:
+                return K_WS_1011;
+            case 1015:
+                return K_WS_1015;
             default:
                 return K_UNKNOWN;
         }

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -9,7 +9,7 @@
            [org.httpkit HttpMethod PrefixThreadFactory HttpUtils]
            [java.util.concurrent ThreadPoolExecutor LinkedBlockingQueue TimeUnit]
            [java.net URI URLEncoder]
-           [org.httpkit.client SslContextFactory MultipartEntity]))
+           [org.httpkit.client ClientSslEngineFactory MultipartEntity]))
 
 ;;;; Utils
 
@@ -65,7 +65,7 @@
                           (str url "&" (query-string query-params)))
                         url)
                  :sslengine (or (:sslengine req)
-                                (when (:insecure? req) (SslContextFactory/trustAnybody)))
+                                (when (:insecure? req) (ClientSslEngineFactory/trustAnybody)))
                  :method    (HttpMethod/fromKeyword (or method :get))
                  :headers   (prepare-request-headers req)
             ;; :body ring body: null, String, seq, InputStream, File, ByteBuffer
@@ -121,7 +121,7 @@
     (if ssl-configurer
       (reify HttpClient$SSLEngineURIConfigurer
         (configure [this ssl-engine uri] (ssl-configurer ssl-engine uri)))
-      HttpClient$SSLEngineURIConfigurer/CLIENT_MODE)
+      HttpClient$SSLEngineURIConfigurer/NOP)
     (if error-logger
       (reify ContextLogger
         (log [this message error] (error-logger message error)))

--- a/test/java/org/httpkit/client/HttpsClientTest.java
+++ b/test/java/org/httpkit/client/HttpsClientTest.java
@@ -38,7 +38,7 @@ public class HttpsClientTest {
         ExecutorService pool = Executors.newCachedThreadPool();
         for (String url : urls) {
             final CountDownLatch cd = new CountDownLatch(1);
-            SSLEngine engine = SslContextFactory.getClientContext().createSSLEngine();
+            SSLEngine engine = ClientSslEngineFactory.trustAnybody();
             RequestConfig cfg = new RequestConfig(HttpMethod.POST, null, null, 40000, 40000, -1, null, false);
             TreeMap<String, Object> headers = new TreeMap<String, Object>();
             for (int i = 0; i < 33; i++) {

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -14,7 +14,7 @@
             [clj-http.client :as clj-http])
   (:import java.nio.ByteBuffer
            [org.httpkit HttpMethod HttpStatus HttpVersion]
-           [org.httpkit.client Decoder IRespListener]))
+           [org.httpkit.client Decoder IRespListener ClientSslEngineFactory]))
 
 (defroutes test-routes
   (GET "/get" [] "hello world")
@@ -299,6 +299,12 @@
   (is (contains? @(http/get "https://apple.com") :status))
   (is (contains? @(http/get "https://microsoft.com") :status))
   (is (contains? @(http/get "https://letsencrypt.org") :status)))
+
+(deftest test-multiple-https-calls-with-same-engine
+  (let [opts {:sslengine (ClientSslEngineFactory/trustAnybody)}]
+    (is (contains? @(http/get "https://localhost:9898" opts) :status))
+    (is (contains? @(http/get "https://localhost:9898" opts) :status))
+    (is (contains? @(http/get "https://localhost:9898" opts) :status))))
 
 ;; https://github.com/http-kit/http-kit/issues/54
 (deftest test-nested-param


### PR DESCRIPTION
The last fix for Java 11 is faulty:

The person didn't explore the reason behind the bug, instead they introduced a second bug:

https://github.com/http-kit/http-kit/blob/master/src/java/org/httpkit/client/HttpClient.java#L361

The change in newer Java versions is was that `getUseClientMode` will now return `true` if the value wasn't set, so it was never set at the linked location, so SslEngine complained about the mode not being set.

The previous fix changed NOOP configurator as default to one that sets `UseClientMode`. Configurator is called here: 

https://github.com/http-kit/http-kit/blob/master/src/java/org/httpkit/client/HttpClient.java#L364

This is problematic for two reasons:

- this SSLEngineURIConfigurer is supplied as default if caller doesn't supply their own. If caller supplies their own SSLEngineURIConfigurer, they will likely not receive the benefits of this fix since the code in the fix never gets called and they will need to add a call to `setUseClientMode` in their own implementation. Suddenly you have a fix that doesn't work for some people and it's not clear why.

- the bigger problem is that the SSLEngineURIConfigurer is called on each http exec call. Combine with the fact that you also get an exception if you call `setUseClientMode` on an SslEngine that has sent any data, this means that if caller specifies their own SslEngine and reuses it for multiple calls, it will break. See additional unit test.
