### PR TITLE
Add error message when no location header is present

### DIFF
--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -290,6 +290,16 @@ public class AsyncChannel {
     static Keyword K_WS_1001 = Keyword.intern("going-away");
     static Keyword K_WS_1002 = Keyword.intern("protocol-error");
     static Keyword K_WS_1003 = Keyword.intern("unsupported");
+    // 1004 is Reserved
+    static Keyword K_WS_1005 = Keyword.intern("no-status-received");
+    static Keyword K_WS_1006 = Keyword.intern("abnormal");
+    static Keyword K_WS_1007 = Keyword.intern("invalid-payload-data");
+    static Keyword K_WS_1008 = Keyword.intern("policy-violation");
+    static Keyword K_WS_1009 = Keyword.intern("message-too-big");
+    static Keyword K_WS_1010 = Keyword.intern("mandatory-extension");
+    static Keyword K_WS_1011 = Keyword.intern("internal-server-error");
+    // 1012 - 1014 are undefined
+    static Keyword K_WS_1015 = Keyword.intern("tls-handshake");
     static Keyword K_UNKNOWN = Keyword.intern("unknown");
 
     private static Keyword readable(int status) {
@@ -306,6 +316,22 @@ public class AsyncChannel {
                 return K_WS_1002;
             case 1003:
                 return K_WS_1003;
+            case 1005:
+                return K_WS_1005;
+            case 1006:
+                return K_WS_1006;
+            case 1007:
+                return K_WS_1007;
+            case 1008:
+                return K_WS_1008;
+            case 1009:
+                return K_WS_1009;
+            case 1010:
+                return K_WS_1010;
+            case 1011:
+                return K_WS_1011;
+            case 1015:
+                return K_WS_1015;
             default:
                 return K_UNKNOWN;
         }

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -228,20 +228,24 @@
                     (if (and follow-redirects
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
-                        (let [location (str (.resolve (URI. url) ^String (.get headers "location")))
-                              change-to-get (and (not allow-unsafe-redirect-methods)
-                                                 (#{301 302 303} status))]
-                          (request (assoc opts ; follow 301 and 302 redirect
-                                     :url location
-                                     :response response
-                                     :query-params (if change-to-get nil (:query-params opts))
-                                     :form-params (if change-to-get nil (:form-params opts))
-                                     :method (if change-to-get
-                                               :get ;; change to :GET
-                                               (:method opts))  ;; do not change
-                                     :trace-redirects (conj trace-redirects url))
-                                   callback))
-                        (deliver-resp {:opts (dissoc opts :response)
+                        (let [^String location-header (.get headers "location")]
+                          (if (nil? location-header)
+                            (deliver-resp {:opts  (dissoc opts :response)
+                                           :error (Exception. (str "No location header is present on redirect response"))})
+                            (let [redirect-location (str (.resolve (URI. url) location-header))
+                                  change-to-get (and (not allow-unsafe-redirect-methods)
+                                                     (#{301 302 303} status))]
+                              (request (assoc opts          ; follow 301 and 302 redirect
+                                         :url redirect-location
+                                         :response response
+                                         :query-params (if change-to-get nil (:query-params opts))
+                                         :form-params (if change-to-get nil (:form-params opts))
+                                         :method (if change-to-get
+                                                   :get     ;; change to :GET
+                                                   (:method opts)) ;; do not change
+                                         :trace-redirects (conj trace-redirects url))
+                                callback))))
+                        (deliver-resp {:opts  (dissoc opts :response)
                                        :error (Exception. (str "too many redirects: "
                                                                (count trace-redirects)))}))
                       (deliver-resp {:opts    (dissoc opts :response)

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -228,23 +228,22 @@
                     (if (and follow-redirects
                              (#{301 302 303 307 308} status)) ; should follow redirect
                       (if (>= max-redirects (count trace-redirects))
-                        (let [^String location-header (.get headers "location")]
-                          (if (nil? location-header)
-                            (deliver-resp {:opts  (dissoc opts :response)
-                                           :error (Exception. (str "No location header is present on redirect response"))})
-                            (let [redirect-location (str (.resolve (URI. url) location-header))
-                                  change-to-get (and (not allow-unsafe-redirect-methods)
-                                                     (#{301 302 303} status))]
-                              (request (assoc opts          ; follow 301 and 302 redirect
-                                         :url redirect-location
-                                         :response response
-                                         :query-params (if change-to-get nil (:query-params opts))
-                                         :form-params (if change-to-get nil (:form-params opts))
-                                         :method (if change-to-get
-                                                   :get     ;; change to :GET
-                                                   (:method opts)) ;; do not change
-                                         :trace-redirects (conj trace-redirects url))
-                                callback))))
+                        (if-let [^String location-header (.get headers "location")]
+                          (let [redirect-location (str (.resolve (URI. url) location-header))
+                                change-to-get (and (not allow-unsafe-redirect-methods)
+                                                   (#{301 302 303} status))]
+                            (request (assoc opts          ; follow 301 and 302 redirect
+                                       :url redirect-location
+                                       :response response
+                                       :query-params (if change-to-get nil (:query-params opts))
+                                       :form-params (if change-to-get nil (:form-params opts))
+                                       :method (if change-to-get
+                                                 :get     ;; change to :GET
+                                                 (:method opts)) ;; do not change
+                                       :trace-redirects (conj trace-redirects url))
+                              callback))
+                          (deliver-resp {:opts  (dissoc opts :response)
+                                         :error (Exception. (str "No location header is present on redirect response"))}))
                         (deliver-resp {:opts  (dissoc opts :response)
                                        :error (Exception. (str "too many redirects: "
                                                                (count trace-redirects)))}))


### PR DESCRIPTION
fixes #403 

Add in a specific error message when a redirect is returned without a location.