### PR TITLE
Fix/issue 410 ipv6 host header

### DIFF
--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -290,6 +290,16 @@ public class AsyncChannel {
     static Keyword K_WS_1001 = Keyword.intern("going-away");
     static Keyword K_WS_1002 = Keyword.intern("protocol-error");
     static Keyword K_WS_1003 = Keyword.intern("unsupported");
+    // 1004 is Reserved
+    static Keyword K_WS_1005 = Keyword.intern("no-status-received");
+    static Keyword K_WS_1006 = Keyword.intern("abnormal");
+    static Keyword K_WS_1007 = Keyword.intern("invalid-payload-data");
+    static Keyword K_WS_1008 = Keyword.intern("policy-violation");
+    static Keyword K_WS_1009 = Keyword.intern("message-too-big");
+    static Keyword K_WS_1010 = Keyword.intern("mandatory-extension");
+    static Keyword K_WS_1011 = Keyword.intern("internal-server-error");
+    // 1012 - 1014 are undefined
+    static Keyword K_WS_1015 = Keyword.intern("tls-handshake");
     static Keyword K_UNKNOWN = Keyword.intern("unknown");
 
     private static Keyword readable(int status) {
@@ -306,6 +316,22 @@ public class AsyncChannel {
                 return K_WS_1002;
             case 1003:
                 return K_WS_1003;
+            case 1005:
+                return K_WS_1005;
+            case 1006:
+                return K_WS_1006;
+            case 1007:
+                return K_WS_1007;
+            case 1008:
+                return K_WS_1008;
+            case 1009:
+                return K_WS_1009;
+            case 1010:
+                return K_WS_1010;
+            case 1011:
+                return K_WS_1011;
+            case 1015:
+                return K_WS_1015;
             default:
                 return K_UNKNOWN;
         }

--- a/src/java/org/httpkit/server/HttpRequest.java
+++ b/src/java/org/httpkit/server/HttpRequest.java
@@ -73,8 +73,12 @@ public class HttpRequest {
     public void setHeaders(Map<String, Object> headers) {
         String h = getStringValue(headers, "host");
         if (h != null) {
+            // the port is an integer following the last ':'
+            // *unless* the last : is prior to the last ] which marks the end of an ipv6 address
+            // https://en.wikipedia.org/wiki/IPv6_address#Literal_IPv6_addresses_in_network_resource_identifiers
+            int ipv6end = (h.charAt(0) == '[') ? h.lastIndexOf(']') : 0;
             int idx = h.lastIndexOf(':');
-            if (idx != -1) {
+            if (idx != -1 && idx > ipv6end) {
                 this.serverName = h.substring(0, idx);
                 serverPort = Integer.valueOf(h.substring(idx + 1));
             } else {

--- a/src/java/org/httpkit/server/HttpRequest.java
+++ b/src/java/org/httpkit/server/HttpRequest.java
@@ -72,7 +72,7 @@ public class HttpRequest {
 
     public void setHeaders(Map<String, Object> headers) {
         String h = getStringValue(headers, "host");
-        if (h != null) {
+        if (h != null && !h.equals("")) {
             // the port is an integer following the last ':'
             // *unless* the last : is prior to the last ] which marks the end of an ipv6 address
             // https://en.wikipedia.org/wiki/IPv6_address#Literal_IPv6_addresses_in_network_resource_identifiers

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -243,6 +243,11 @@
     (is (= (:status resp) 200))
     (is (= "" (:body resp)))))
 
+(deftest ipv6-host-header
+  (let [resp (http/get "http://localhost:4347/"
+                       {:headers {"host" "[::ffff:a9fe:a9fe]"}})]
+    (is (= 200 (:status resp)))))
+
 ;;;;; async
 
 (deftest test-timer

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -253,6 +253,11 @@
                        {:headers {"host" "[::ffff:a9fe:a9fe]:80"}})]
     (is (= 200 (:status resp)))))
 
+(deftest ipv6-blank-host-header
+  (let [resp (http/get "http://localhost:4347/"
+                       {:headers {"host" ""}})]
+    (is (= 200 (:status resp)))))
+
 ;;;;; async
 
 (deftest test-timer

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -248,6 +248,11 @@
                        {:headers {"host" "[::ffff:a9fe:a9fe]"}})]
     (is (= 200 (:status resp)))))
 
+(deftest ipv6-host-header-with-port
+  (let [resp (http/get "http://localhost:4347/"
+                       {:headers {"host" "[::ffff:a9fe:a9fe]:80"}})]
+    (is (= 200 (:status resp)))))
+
 ;;;;; async
 
 (deftest test-timer


### PR DESCRIPTION
special-case the parsing for ipv6, if the host header starts with [

then find the index of ] and if the last : is prior to that,
then do not incorrectly treat the rest of the string as the port

this is an attempt to fix #410
