### PR TITLE
#393 - workaround and documentation for SNI issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,31 @@ A big thank you to the **[current contributors](https://github.com/http-kit/http
 
 \- [@ptaoussanis][]
 
+### Debugging SSLHandshakeException [SNI support to be enabled by default?](http)s://github.com/http-kit/http-kit/issues/393)
+
+If you just use http-kit client and you get an exception:
+
+`javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure`
+
+it means that you are trying to contact a website which uses SNI during
+the SSL handshake but the default client does not handle SNI properly and
+this generates the handshake exception.
+
+Since this is a common source of confusion, a new namespace have been
+introduced (`org.httpkit.sni-client`) which provides a pre configured
+client with a :sni-configurer in the var `default-sni-client`.
+
+The new default-sni-client can be used as is (just remenber to deref it),
+passing it to `request` function via the :client option, or can be set as
+the default one for the whole application:
+
+``` clojure
+(alter-var-root #'org.httpkit.client/*default-client* default-sni-client)
+```
+
+Please refer to `org.httpkit.sni-client` and `org.httpkit.client`
+namespaces for further details.
+
 ### Hack locally
 
 Hacker friendly: zero dependencies, written from the ground-up with only ~3.5k lines of code (including java), clean and tidy.

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -290,6 +290,16 @@ public class AsyncChannel {
     static Keyword K_WS_1001 = Keyword.intern("going-away");
     static Keyword K_WS_1002 = Keyword.intern("protocol-error");
     static Keyword K_WS_1003 = Keyword.intern("unsupported");
+    // 1004 is Reserved
+    static Keyword K_WS_1005 = Keyword.intern("no-status-received");
+    static Keyword K_WS_1006 = Keyword.intern("abnormal");
+    static Keyword K_WS_1007 = Keyword.intern("invalid-payload-data");
+    static Keyword K_WS_1008 = Keyword.intern("policy-violation");
+    static Keyword K_WS_1009 = Keyword.intern("message-too-big");
+    static Keyword K_WS_1010 = Keyword.intern("mandatory-extension");
+    static Keyword K_WS_1011 = Keyword.intern("internal-server-error");
+    // 1012 - 1014 are undefined
+    static Keyword K_WS_1015 = Keyword.intern("tls-handshake");
     static Keyword K_UNKNOWN = Keyword.intern("unknown");
 
     private static Keyword readable(int status) {
@@ -306,6 +316,22 @@ public class AsyncChannel {
                 return K_WS_1002;
             case 1003:
                 return K_WS_1003;
+            case 1005:
+                return K_WS_1005;
+            case 1006:
+                return K_WS_1006;
+            case 1007:
+                return K_WS_1007;
+            case 1008:
+                return K_WS_1008;
+            case 1009:
+                return K_WS_1009;
+            case 1010:
+                return K_WS_1010;
+            case 1011:
+                return K_WS_1011;
+            case 1015:
+                return K_WS_1015;
             default:
                 return K_UNKNOWN;
         }

--- a/src/org/httpkit/sni_client.clj
+++ b/src/org/httpkit/sni_client.clj
@@ -1,0 +1,42 @@
+(ns org.httpkit.sni-client
+  "This namespace provides a default client with a pre-configured
+  :sni-configurer key as a workaround for the issue
+  https://github.com/http-kit/http-kit/issues/393
+
+  direct link to comment with proposed workaround
+  https://github.com/http-kit/http-kit/issues/393#issuecomment-563820823"
+  (:require [org.httpkit.client :as http-client])
+  (:import java.net.URI
+           [javax.net.ssl SNIHostName SSLEngine]))
+
+(defn ssl-configurer [^SSLEngine eng, ^URI uri]
+  (let [host-name (SNIHostName. (.getHost uri))
+        params (doto (.getSSLParameters eng)
+                 (.setServerNames [host-name]))]
+    (doto eng
+      (.setUseClientMode true) ;; required for JDK12/13 but not for JDK1.8
+      (.setSSLParameters params))))
+
+(defonce
+  ^{:doc "Client with a default :sni-configurer option; it can be
+used directly, as a parameter to `org.httpkit.client/request` call,
+set as a default for the whole application by using `alter-root-var`
+or set as a per-thread default by dynamicly rebinding
+`org.httpkit.client/*default-client*`; examples code provided in the
+following comment section."}
+  default-sni-client
+  (delay (http-client/make-client {:ssl-configurer ssl-configurer})))
+
+(comment
+  ;; redifine the default client for the whole application
+  (alter-var-root #'org.httpkit.client/*default-client*
+    (fn [_]
+      default-sni-client))
+
+  ;; this call to get will use default-sni-client client
+  (org.http-kit.client/get "https://example.com")
+
+  ;; specify a custom client for a particular context
+  (binding [org.httpkit.client/*default-client* default-sni-client]
+    (org.httpkit.client/get "https://example.com"))
+  )


### PR DESCRIPTION
This PR contains:
- a change in org.http-kit.client to enable the customization of the default client
- a new namespace org.http-kit.sni-client that incudes a default client with :sni-configurer option
- a bit of documentation in the README.md about the SSLHandshakeException problem and how to address it.