### PR TITLE
New `default-client-https` behaving similarly to `URL.openStream()`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   ["-Dclojure.compiler.disable-locals-clearing=true"
    "-Xms1g" "-Xmx1g"] ; Testing https require more memory
 
-  :javac-options ["-source" "1.6" "-target" "1.6" "-g"]
+  :javac-options ["-source" "1.7" "-target" "1.7" "-g"]
   :java-source-paths ["src/java"]
   :test-paths ["test"]
   :jar-exclusions [#"^java.*"] ; exclude the java directory in source path

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -73,7 +73,7 @@
      (.setSSLParameters ssl-engine ssl-params))))
 
 (defn- coerce-req
-  [{:keys [url method body insecure? sslengine query-params form-params multipart]
+  [{:keys [url method body sslengine query-params form-params multipart]
     :as req}]
   (let [r (assoc req
                  :url (if query-params
@@ -82,7 +82,7 @@
                           (str url "&" (query-string query-params)))
                         url)
                  :sslengine (or sslengine
-                                (when insecure?
+                                (when (:insecure? req)
                                   (ClientSslEngineFactory/trustAnybody)))
                  :method    (HttpMethod/fromKeyword (or method :get))
                  :headers   (prepare-request-headers req)
@@ -146,7 +146,7 @@ an SNI-capable one, e.g.:
   "Returns an HttpClient with specified options:
     :max-connections    ; Max connection count, default is unlimited (-1)
     :address-finder     ; (fn [java.net.URI]) -> java.net.InetSocketAddress
-    :ssl-configurer     ; (fn [javax.net.ssl.SSLEngine java.net.URI & flags])
+    :ssl-configurer     ; (fn [javax.net.ssl.SSLEngine java.net.URI])
     :error-logger       ; (fn [text ex])
     :event-logger       ; (fn [event-name])
     :event-names        ; {<http-kit-event-name> <loggable-event-name>}

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -57,7 +57,7 @@
 
 (comment (query-string {:k1 "v1" :k2 "v2" :k3 nil :k4 ["v4a" "v4b"] :k5 []}))
 
-(defn- https-engine
+(defn https-engine
   ^SSLEngine [^SSLContext ssl-ctx url]
   (let [addr (-> HttpClient$AddressFinder/DEFAULT
                  (.findAddress (URI. url)))]
@@ -71,7 +71,6 @@
    (https-configurer engine uri :hostname-verification))
   ([^SSLEngine ssl-engine ^URI uri & opts]
    (let [^SSLParameters ssl-params (.getSSLParameters ssl-engine)]
-     (println (vec opts))
      (when (some hv? opts)
        (.setEndpointIdentificationAlgorithm ssl-params "HTTPS"))
      (when (some sni? opts)
@@ -154,8 +153,6 @@ an SNI-capable one, e.g.:
   [{:keys [max-connections
            address-finder
            ssl-configurer
-           sni                   ;; server-name-indication flag - optional
-           hostname-verification ;; hostname verification flag  - optional
            error-logger
            event-logger
            event-names

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -57,12 +57,6 @@
 
 (comment (query-string {:k1 "v1" :k2 "v2" :k3 nil :k4 ["v4a" "v4b"] :k5 []}))
 
-(defn https-engine
-  ^SSLEngine [^SSLContext ssl-ctx url]
-  (let [addr (-> HttpClient$AddressFinder/DEFAULT
-                 (.findAddress (URI. url)))]
-    (.createSSLEngine  ssl-ctx (.getHostName addr) (.getPort addr))))
-
 (def ^:private sni? (partial = :sni))
 (def ^:private hv?  (partial = :hostname-verification))
 
@@ -88,7 +82,8 @@
                           (str url "&" (query-string query-params)))
                         url)
                  :sslengine (or sslengine
-                                (some-> ssl-context (https-engine url))
+                                ;; allow for SSLContext param
+                                (some-> ssl-context .createSSLEngine)
                                 (when insecure?
                                   (ClientSslEngineFactory/trustAnybody)))
                  :method    (HttpMethod/fromKeyword (or method :get))

--- a/src/org/httpkit/sni_client.clj
+++ b/src/org/httpkit/sni_client.clj
@@ -2,20 +2,16 @@
   "Provides an SNI-capable SSL configurer and client, Ref. #335.
   In a separate namespace from `org.httpkit.client` so that
   http-kit can retain backwards-compatibility with JVM < 8."
+  (:require [clojure.string :as str])
   (:import [java.net URI]
            [javax.net.ssl SNIHostName SSLEngine SSLParameters]))
 
-(defn ssl-configurer
-  "SNI-capable SSL configurer.
-  May be used as an argument to `org.httpkit.client/make-client`:
-    (make-client :ssl-configurer (ssl-configurer))"
-  [^SSLEngine ssl-engine ^URI uri]
-  (let [host-name  (SNIHostName. (.getHost uri))
-        ssl-params (doto (.getSSLParameters ssl-engine)
-                     (.setServerNames [host-name]))]
-    (doto ssl-engine
-      (.setUseClientMode true) ; required for JVM 12/13 but not for JVM 8
-      (.setSSLParameters ssl-params))))
+(defonce jv ;; java major version as an int
+  (delay
+    (-> (System/getProperty "java.version")
+        (str/split #"\.")
+        first
+        Integer/parseInt)))
 
 (def ^:private sni? (partial = :sni))
 (def ^:private hv?  (partial = :hostname-verification))
@@ -39,13 +35,14 @@
          ;; java.lang.IllegalArgumentException:
          ;; Cannot change mode after SSL traffic has started
          ;; at sun.security.ssl.SSLEngineImpl.setUseClientMode
-         (not client-mode?)
+         (or (not client-mode?)
+             (>= (force jv) 11))
          (.setUseClientMode true))
        (.setSSLParameters ssl-params)))))
 
 
 
-(defonce
+(def
   ^{:doc "Like `org.httpkit.client/default-client`, but provides SNI support using `ssl-configurer`"}
   default-client
   (delay

--- a/src/org/httpkit/sni_client.clj
+++ b/src/org/httpkit/sni_client.clj
@@ -3,7 +3,7 @@
   In a separate namespace from `org.httpkit.client` so that
   http-kit can retain backwards-compatibility with JVM < 8."
   (:import [java.net URI]
-           [javax.net.ssl SNIHostName SSLEngine]))
+           [javax.net.ssl SNIHostName SSLEngine SSLParameters]))
 
 (defn ssl-configurer
   "SNI-capable SSL configurer.
@@ -16,6 +16,27 @@
     (doto ssl-engine
       (.setUseClientMode true) ; required for JVM 12/13 but not for JVM 8
       (.setSSLParameters ssl-params))))
+
+(def ^:private sni? (partial = :sni))
+(def ^:private hv?  (partial = :hostname-verification))
+
+(defn ssl-configurer
+  "SNI-capable SSL configurer.
+   May be used as an argument to `org.httpkit.client/make-client`:
+    (make-client :ssl-configurer (ssl-configurer))"
+  ([engine uri]
+   (ssl-configurer engine uri :hostname-verification :sni))
+  ([^SSLEngine ssl-engine ^URI uri & opts]
+   (let [^SSLParameters ssl-params (.getSSLParameters ssl-engine)]
+     (when (some hv? opts)
+       (.setEndpointIdentificationAlgorithm ssl-params "HTTPS"))
+     (when (some sni? opts)
+       (.setServerNames ssl-params [(SNIHostName. (.getHost uri))]))
+     (doto ssl-engine
+       (.setUseClientMode true) ; required for JVM 12/13 but not for JVM 8
+       (.setSSLParameters ssl-params)))))
+
+
 
 (defonce
   ^{:doc "Like `org.httpkit.client/default-client`, but provides SNI support using `ssl-configurer`"}

--- a/test/org/httpkit/client_https_test.clj
+++ b/test/org/httpkit/client_https_test.clj
@@ -7,19 +7,26 @@
 
 (deftest client-https-tests
   (testing "`sni/default-client` behaves similarly to `URL.openStream()`"
-    (let [sslengine (.createSSLEngine (SSLContext/getDefault))
-          https-client (force sni/default-client)
+    (let [https-client (force sni/default-client)
           url1 "https://wrong.host.badssl.com"
           url2 "https://self-signed.badssl.com"
           url3 "https://untrusted-root.badssl.com"]
 
+      (is (nil?
+            (:error
+              @(http/request
+                 {:client  https-client
+                  :sslengine (.createSSLEngine (SSLContext/getDefault))
+                  :keepalive -1
+                  :url "https://www.bbc.co.uk"}))))
+
       (let [exception (:error
                         @(http/request
                            {:client https-client
-                            :sslengine sslengine
+                            :sslengine (.createSSLEngine (SSLContext/getDefault))
                             :keepalive -1
                             :url url1}))]
-                ;; Java 9 and above throws proper SSLHandshakeException
+                ;; Java 12 and above throws proper SSLHandshakeException
         (is (or (instance? SSLHandshakeException exception)
                 ;; Java 8 throws RuntimeException at sun.security.ssl.Handshaker
                 (instance? RuntimeException exception))))
@@ -28,7 +35,7 @@
                      (:error
                        @(http/request
                           {:client  https-client
-                           :sslengine sslengine
+                           :sslengine (.createSSLEngine (SSLContext/getDefault))
                            :keepalive -1
                            :url url2}))))
 
@@ -36,9 +43,18 @@
                      (:error
                        @(http/request
                           {:client  https-client
-                           :sslengine sslengine
+                           :sslengine (.createSSLEngine (SSLContext/getDefault))
                            :keepalive -1
                            :url url3}))))
+
+      (is (nil?
+              (:error
+                @(http/request
+                   {:client  https-client
+                    :sslengine (.createSSLEngine (SSLContext/getDefault))
+                    :keepalive -1
+                    :url "https://github.com"}))
+              ))
 
       )
     )

--- a/test/org/httpkit/client_https_test.clj
+++ b/test/org/httpkit/client_https_test.clj
@@ -1,0 +1,40 @@
+(ns org.httpkit.client-https-test
+  (:require [clojure.test :refer :all]
+            [org.httpkit.client :as http])
+  (:import (javax.net.ssl SSLHandshakeException SSLException)))
+
+
+(deftest client-https-tests
+  (testing "`default-client-https` behaves similarly to `URL.openStream()`"
+    (let [sslengine (http/make-ssl-engine)
+          url1 "https://wrong.host.badssl.com"
+          url2 "https://self-signed.badssl.com"
+          url3 "https://untrusted-root.badssl.com"]
+
+      (is (instance? SSLHandshakeException
+                     (:error
+                       @(http/request
+                          {:client :default-https
+                           :sslengine sslengine
+                           :keepalive -1
+                           :url url1}))))
+
+      (is (instance? SSLException
+                     (:error
+                       @(http/request
+                          {:client :default-https
+                           :sslengine sslengine
+                           :keepalive -1
+                           :url url2}))))
+
+      (is (instance? SSLException
+                     (:error
+                       @(http/request
+                          {:client :default-https
+                           :sslengine sslengine
+                           :keepalive -1
+                           :url url3}))))
+
+      )
+    )
+  )

--- a/test/org/httpkit/client_https_test.clj
+++ b/test/org/httpkit/client_https_test.clj
@@ -6,7 +6,7 @@
 
 
 (deftest client-https-tests
-  (testing "`default-client-https` behaves similarly to `URL.openStream()`"
+  (testing "`sni/default-client` behaves similarly to `URL.openStream()`"
     (let [sslengine (.createSSLEngine (SSLContext/getDefault))
           https-client (force sni/default-client)
           url1 "https://wrong.host.badssl.com"


### PR DESCRIPTION
There is a new delayed Var called `default-client-https`. Using this instead of the standard `default-client` will make your client object behave like `URL.openStream()`, which i think is desirable. Addresses #344  - at the very least on Java11+.  