### PR TITLE
[#427] [Client] Improve prepare-request-headers performance x3

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -25,11 +25,11 @@
 
 (defn- prepare-request-headers
   [{:keys [headers form-params basic-auth oauth-token user-agent] :as req}]
-  (merge headers
-         (when form-params {"Content-Type"  "application/x-www-form-urlencoded"})
-         (when basic-auth  {"Authorization" (basic-auth-value basic-auth)})
-         (when oauth-token {"Authorization" (str "Bearer " oauth-token)})
-         (when user-agent  {"User-Agent"    user-agent})))
+  (cond-> headers
+    form-params (assoc "Content-Type"  "application/x-www-form-urlencoded")
+    basic-auth  (assoc "Authorization" (basic-auth-value basic-auth))
+    oauth-token (assoc "Authorization" (str "Bearer " oauth-token))
+    user-agent  (assoc "User-Agent"    user-agent)))
 
 (defn- prepare-response-headers [headers]
   (reduce (fn [m [k v]] (assoc m (keyword k) v)) {} headers))


### PR DESCRIPTION
Closes #427, about x3 faster, new implementation is marked with `*`
```clojure
(def req
  {:headers {}
   :form-params 'params
   :basic-auth "Basic"
   :auth-token "ToKeN"
   :user-agent "UA"})

(=
 (prepare-request-headers req)
 (prepare-request-headers* req))

(require '[criterium.core :as cc])

(cc/bench (prepare-request-headers {}))

;;; Evaluation count : 211035300 in 60 samples of 3517255 calls.
;;;              Execution time mean : 287.436409 ns
;;;     Execution time std-deviation : 7.965019 ns
;;;    Execution time lower quantile : 275.729529 ns ( 2.5%)
;;;    Execution time upper quantile : 303.992177 ns (97.5%)
;;;                    Overhead used : 2.170582 ns
;;;
;;; Found 2 outliers in 60 samples (3.3333 %)
;;; 	low-severe	 2 (3.3333 %)
;;;  Variance from outliers : 14.2369 % Variance is moderately inflated by outliers

(cc/bench (prepare-request-headers req))

;;; Evaluation count : 48521700 in 60 samples of 808695 calls.
;;;              Execution time mean : 1.261311 µs
;;;     Execution time std-deviation : 53.305322 ns
;;;    Execution time lower quantile : 1.207408 µs ( 2.5%)
;;;    Execution time upper quantile : 1.375263 µs (97.5%)
;;;                    Overhead used : 2.170582 ns
;;;
;;; Found 1 outliers in 60 samples (1.6667 %)
;;; 	low-severe	 1 (1.6667 %)
;;;  Variance from outliers : 28.6878 % Variance is moderately inflated by outliers

(cc/bench (prepare-request-headers* {}))

;;; Evaluation count : 657554040 in 60 samples of 10959234 calls.
;;;              Execution time mean : 91.599632 ns
;;;     Execution time std-deviation : 3.579694 ns
;;;    Execution time lower quantile : 88.386273 ns ( 2.5%)
;;;    Execution time upper quantile : 99.598973 ns (97.5%)
;;;                    Overhead used : 2.170582 ns
;;;
;;; Found 3 outliers in 60 samples (5.0000 %)
;;; 	low-severe	 3 (5.0000 %)
;;;  Variance from outliers : 25.4541 % Variance is moderately inflated by outliers

(cc/bench (prepare-request-headers* req))

;;; Evaluation count : 137967660 in 60 samples of 2299461 calls.
;;;              Execution time mean : 453.724757 ns
;;;     Execution time std-deviation : 25.636622 ns
;;;    Execution time lower quantile : 430.093760 ns ( 2.5%)
;;;    Execution time upper quantile : 518.989340 ns (97.5%)
;;;                    Overhead used : 2.170582 ns
;;;
;;; Found 4 outliers in 60 samples (6.6667 %)
;;; 	low-severe	 4 (6.6667 %)
;;;  Variance from outliers : 41.8016 % Variance is moderately inflated by outliers
```