### PR TITLE
Server header

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit "2.4.0"
+(defproject http-kit "2.4.1-SNAPSHOT"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"
@@ -54,5 +54,5 @@
      [compojure                      "1.5.2"] ; TODO Update (breaking)
      [org.clojure/tools.cli          "0.3.3"] ; TODO Update (breaking)
      [ring/ring-jetty-adapter        "1.5.1"] ; TODO Update (breaking)
-     [ring/ring-core                 "1.5.1"] ; TODO Update (breaking)
-     ]}})
+     [ring/ring-core                 "1.5.1"]]}}) ; TODO Update (breaking)
+     

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -439,6 +439,10 @@ public class HttpUtils {
     public static final String CL = "Content-Length";
 
     public static ByteBuffer[] HttpEncode(int status, HeaderMap headers, Object body) {
+        return HttpEncode(status, headers, body, null);
+    }
+
+    public static ByteBuffer[] HttpEncode(int status, HeaderMap headers, Object body, String serverHeader) {
         ByteBuffer bodyBuffer;
         try {
             bodyBuffer = bodyBuffer(body);
@@ -458,8 +462,8 @@ public class HttpUtils {
             headers.put(CL, Integer.toString(b.length));
             bodyBuffer = ByteBuffer.wrap(b);
         }
-        if (!headers.containsKey("Server")) {
-          headers.put("Server", "http-kit");
+        if (serverHeader != null && !headers.containsKey("Server")) {
+          headers.put("Server", serverHeader);
         }
         if (!headers.containsKey("Date")) {
           headers.put("Date", DateFormatter.getDate()); // rfc says the Date is needed

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -117,12 +117,12 @@ public class AsyncChannel {
         }
 
         if (close) { // normal response, Content-Length. Every http client understand it
-            buffers = HttpEncode(status, headers, body);
+            buffers = HttpEncode(status, headers, body, server.serverHeader);
         } else {
             if (request.version == HttpVersion.HTTP_1_1) {
                 headers.put("Transfer-Encoding", "chunked"); // first chunk
             }
-            ByteBuffer[] bb = HttpEncode(status, headers, body);
+            ByteBuffer[] bb = HttpEncode(status, headers, body, server.serverHeader);
             if (body == null) {
                 buffers = bb;
             } else {

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -48,6 +48,7 @@ Options:
     :warn-logger        ; Arity-2 fn (args: string text, exception) to log warnings
     :event-logger       ; Arity-1 fn (arg: string event name)
     :event-names        ; map of HTTP-Kit event names to respective loggable event names
+    :server-header      ; The \"Server\" header. If missing, defaults to http-kit, disabled if nil
 
   If :legacy-return-value? is
     true  (default)     ; Returns a (fn stop-server [& {:keys [timeout] :or {timeout 100}}])
@@ -60,7 +61,7 @@ Options:
    & [{:keys [ip port thread queue-size max-body max-ws max-line
               proxy-protocol worker-name-prefix worker-pool
               error-logger warn-logger event-logger event-names
-              legacy-return-value?]
+              legacy-return-value? server-header]
 
        :or   {ip         "0.0.0.0"
               port       8090
@@ -71,7 +72,8 @@ Options:
               max-line   8192
               proxy-protocol :disable
               worker-name-prefix "worker-"
-              legacy-return-value? true}}]]
+              legacy-return-value? true
+              server-header "http-kit"}}]]
 
   (let [err-logger (if error-logger
                      (reify ContextLogger
@@ -90,14 +92,15 @@ Options:
                                                  (format "Invalid event-names: (%s) %s"
                                                    (class event-names) (pr-str event-names)))))
         h (if worker-pool
-            (RingHandler. handler worker-pool err-logger evt-logger evt-names)
-            (RingHandler. thread handler worker-name-prefix queue-size err-logger evt-logger evt-names))
+            (RingHandler. handler worker-pool err-logger evt-logger evt-names server-header)
+            (RingHandler. thread handler worker-name-prefix queue-size server-header err-logger evt-logger evt-names))
         proxy-enum (case proxy-protocol
                      :enable   ProxyProtocolOption/ENABLED
                      :disable  ProxyProtocolOption/DISABLED
                      :optional ProxyProtocolOption/OPTIONAL)
 
         s (HttpServer. ip port h max-body max-line max-ws proxy-enum
+            server-header
             err-logger
             (if warn-logger
               (reify ContextLogger

--- a/test/java/org/httpkit/server/RingHandlerTest.java
+++ b/test/java/org/httpkit/server/RingHandlerTest.java
@@ -42,7 +42,7 @@ public class RingHandlerTest {
     public void shouldUseInternalThreadPoolForExecution() throws InterruptedException, ProtocolException, LineTooLargeException, RequestTooLargeException {
         Vector<String> assertionItems = new Vector<String>();
 
-        RingHandler ringHandler = new RingHandler(1, new MockClojureHandler(aDummyResponse()), "some-prefix", 2);
+        RingHandler ringHandler = new RingHandler(1, new MockClojureHandler(aDummyResponse()), "some-prefix", 2, "http-kit");
         ringHandler.handle(aDummyRequest(), new MockRespCallback(assertionItems));
 
         Thread.sleep(50);

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -73,8 +73,8 @@
                          p
                          {:body p})
                false))        ;; do not close
-      (send! channel "" true) ;; same as (close channel)
-)))
+      (send! channel "" true)))) ;; same as (close channel)
+
 
 (defn slow-server-handler [req]
   (with-channel req channel
@@ -447,3 +447,32 @@
 
     (is (= (server-status server) :stopped))
     (is (= (:status @resp_) 200))))
+
+(deftest test-server-header
+  (let [get-server-header (fn [headers]
+                            (reduce-kv (fn [res k v]
+                                         (if (= k "Server")
+                                           (reduced v)
+                                           res))
+                                       nil
+                                       headers))
+        url #(format "http://localhost:%s/headers?count=1" %)]
+
+    (let [server (run-server (site test-routes) {:port 3475 :server-header nil})
+          resp (http/get (url 3475))]
+     (is (= (:status resp) 200))
+     (is (nil? (get-server-header (:headers resp))))
+     (server))
+
+    (let [server (run-server (site test-routes) {:port 3476})
+          resp (http/get (url 3476))]
+       (is (= (:status resp) 200))
+       (is (= "http-kit" (get-server-header (:headers resp))))
+       (server))
+
+    (let [server (run-server (site test-routes) {:port 3477 :server-header "my-server"})
+          resp (http/get (url 3477))]
+       (is (= (:status resp) 200))
+       (is (= "my-server" (get-server-header (:headers resp))))
+       (server))))
+


### PR DESCRIPTION
configurable server header
    
configurable server header by using the `:server-header`
key for `run-server`.
omitting the key leaves default old behavior
("http-kit"), passing `nil` removes the header.
closes #129