### PR TITLE
GraalVM Native Image Compatibility: move SSL initialisation to constructor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject http-kit "2.4.0"
+(defproject http-kit "2.4.1-SNAPSHOT"
   :author "Feng Shen (@shenfeng)"
   :description "High-performance event-driven HTTP client/server for Clojure"
   :url "http://http-kit.org/"

--- a/src/java/org/httpkit/client/ClientSslEngineFactory.java
+++ b/src/java/org/httpkit/client/ClientSslEngineFactory.java
@@ -11,11 +11,9 @@ import java.security.cert.X509Certificate;
 public class ClientSslEngineFactory {
 
     private static final String PROTOCOL = "TLS";
-    private static final SSLContext CLIENT_CONTEXT;
+    private static SSLContext clientContext = null;
 
-    static {
-        SSLContext clientContext = null;
-
+    public static SSLEngine trustAnybody() {
         try {
             clientContext = SSLContext.getInstance(PROTOCOL);
             clientContext.init(null, TrustManagerFactory.getTrustManagers(),
@@ -24,12 +22,8 @@ public class ClientSslEngineFactory {
             throw new Error(
                     "Failed to initialize the client-side SSLContext", e);
         }
-
-        CLIENT_CONTEXT = clientContext;
-    }
-
-    public static SSLEngine trustAnybody() {
-        SSLEngine engine = CLIENT_CONTEXT.createSSLEngine();
+        
+        SSLEngine engine = clientContext.createSSLEngine();
         engine.setUseClientMode(true);
         return engine;
     }


### PR DESCRIPTION
- The static block loads SSLContext on to the heap, this prevents compilation when creating a native image with GraalVM.
- Moving to constructor only loads SSLContext at run time.
- Use singleton to still allow read access to clientSSLContext (was `public static final` before)

This change means that both  server and client can be compiled to a native binary. This would make it the most feature rich http client compatible with native image creation. (see [BrunoBonacci/graalvm-clojure](https://github.com/BrunoBonacci/graalvm-clojure/))