### PR TITLE
Use Java7 compatible method to join string in tests

### DIFF
--- a/test/java/org/httpkit/server/RingHandlerTest.java
+++ b/test/java/org/httpkit/server/RingHandlerTest.java
@@ -71,7 +71,26 @@ public class RingHandlerTest {
 
     private HttpRequest asHttpRequest(String... requestLines) throws ProtocolException, LineTooLargeException, RequestTooLargeException {
         httpDecoder.reset();
-        String joinedRequest = String.join("\n", requestLines);
+        
+        // String joinedRequest = String.join("\n", requestLines); 
+        // String.join is was only released in 1.8
+        
+        String joinedRequest = "";
+        int requestLength = requestLines.length;
+
+        if (requestLines != null && requestLength > 0) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < requestLength; i++) {
+
+                sb.append(requestLines[i]);
+
+                if (i != requestLength - 1) {
+                    sb.append("\n");
+                }
+
+            }
+            joinedRequest = sb.toString();
+        }
         return httpDecoder.decode(ByteBuffer.wrap((joinedRequest + "\n\n").getBytes()));
     }
 


### PR DESCRIPTION
**Change**
Join strings manually in test. `String.join` was only released in 1.8 so tests fail when running with `--release 7`.
https://docs.oracle.com/javase/8/docs/api/java/lang/String.html 

**Effect**
This allows the test suite to run against Java 7. No impact on actual library. 

**Why this matters**
This will allow us to create Github Actions and thus setup automated tests (and perhaps coverage) for all pushes and pull requests. The Github Actions currently fail because of `--release 7`

