### PR TITLE
[Feature] Add multipart/mixed basic support

### DIFF
--- a/src/java/org/httpkit/client/MultipartEntity.java
+++ b/src/java/org/httpkit/client/MultipartEntity.java
@@ -34,16 +34,18 @@ public class MultipartEntity {
         return "----HttpKitFormBoundary" + System.currentTimeMillis();
     }
 
-    public static ByteBuffer encode(String boundary, List<MultipartEntity> entities) throws IOException {
+    public static ByteBuffer encode(String boundary, List<MultipartEntity> entities, Boolean multipartMixed) throws IOException {
         DynamicBytes bytes = new DynamicBytes(entities.size() * 1024);
         for (MultipartEntity e : entities) {
             bytes.append("--").append(boundary).append(HttpUtils.CR, HttpUtils.LF);
-            bytes.append("Content-Disposition: form-data; name=\"");
-            bytes.append(e.name, HttpUtils.UTF_8);
-            if (e.filename != null) {
-                bytes.append("\"; filename=\"").append(e.filename).append("\"\r\n");
-            } else {
-                bytes.append("\"\r\n");
+            if (multipartMixed == null || !multipartMixed) {
+                bytes.append("Content-Disposition: form-data; name=\"");
+                bytes.append(e.name, HttpUtils.UTF_8);
+                if (e.filename != null) {
+                    bytes.append("\"; filename=\"").append(e.filename).append("\"\r\n");
+                } else {
+                    bytes.append("\"\r\n");
+                }
             }
 
             if (e.contentType != null) {

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -58,7 +58,7 @@
 (comment (query-string {:k1 "v1" :k2 "v2" :k3 nil :k4 ["v4a" "v4b"] :k5 []}))
 
 (defn- coerce-req
-  [{:keys [url method body sslengine insecure? query-params form-params multipart] :as req}]
+  [{:keys [url method body sslengine insecure? query-params form-params multipart multipart-mixed?] :as req}]
   (let [r (assoc req
                  :url (if query-params
                         (if (neg? (.indexOf ^String url (int \?)))
@@ -77,8 +77,8 @@
             boundary (MultipartEntity/genBoundary entities)]
         (-> r
             (assoc-in [:headers "Content-Type"]
-                      (str "multipart/form-data; boundary=" boundary))
-            (assoc :body (MultipartEntity/encode boundary entities))))
+                      (str "multipart/" (if multipart-mixed? "mixed" "form-data")"; boundary=" boundary))
+            (assoc :body (MultipartEntity/encode boundary entities multipart-mixed?))))
       r)))
 
 ;; thread pool for executing callbacks, since they may take a long time to execute.


### PR DESCRIPTION
- Related issue: #224

Basic multipart/mixed support by accepting a `multipart-mixed?` flag that forces the `Content-Type` and remove the `Content-Disposition` Header (since it relates to form-data requests only) 

I've added a couple of assertions to check if the request-map is being coerced properly
Tests are passing locally ✔️ 

Any suggestions are welcome :) 

