### PR TITLE
Same `HttpClient` instance should be used when following redirects

### DIFF
--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -386,8 +386,8 @@
                 {:client-id :var-root :url url-2}]
                @call-log)))
       (testing "closed over and used for subsequent requests"
-        (let [wrap-blocking (fn [^org.httpkit.client.HttpClient client p]
-                              (proxy [org.httpkit.client.HttpClient] []
+        (let [wrap-blocking (fn [^HttpClient client p]
+                              (proxy [HttpClient] []
                                 (exec [url cfg sslengine ^org.httpkit.client.IRespListener listener]
                                   (let [blocking-listener (reify org.httpkit.client.IRespListener
                                                             (onInitialLineReceived [this version status]

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -15,7 +15,7 @@
             [clj-http.client :as clj-http])
   (:import java.nio.ByteBuffer
            [org.httpkit HttpMethod HttpStatus HttpVersion DynamicBytes]
-           [org.httpkit.client Decoder IRespListener ClientSslEngineFactory]
+           [org.httpkit.client Decoder IRespListener ClientSslEngineFactory HttpClient]
            [javax.net.ssl SSLHandshakeException SSLException SSLContext]))
 
 (deftest ssl-engine-factory-race-condition
@@ -374,7 +374,7 @@
   (let [url-1 "http://localhost:4347/redirect?total=1&n=0"
         url-2 "http://localhost:4347/redirect?total=1&n=1&code=302"
         recording-client (fn [call-log-atom id]
-                           (proxy [org.httpkit.client.HttpClient] []
+                           (proxy [HttpClient] []
                              (exec [url cfg sslengine listener]
                                (swap! call-log-atom conj {:client-id id :url url})
                                (proxy-super exec url cfg sslengine listener))))]

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -388,8 +388,8 @@
       (testing "closed over and used for subsequent requests"
         (let [wrap-blocking (fn [^HttpClient client p]
                               (proxy [HttpClient] []
-                                (exec [url cfg sslengine ^org.httpkit.client.IRespListener listener]
-                                  (let [blocking-listener (reify org.httpkit.client.IRespListener
+                                (exec [url cfg sslengine ^IRespListener listener]
+                                  (let [blocking-listener (reify IRespListener
                                                             (onInitialLineReceived [this version status]
                                                               (.onInitialLineReceived listener version status))
                                                             (onHeadersReceived [this headers]

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -369,6 +369,46 @@
                            :keepalive -1
                            :url url3})))))))
 
+(deftest test-redirect-with-client
+  (let [url-1 "http://localhost:4347/redirect?total=1&n=0"
+        url-2 "http://localhost:4347/redirect?total=1&n=1&code=302"
+        recording-client (fn [call-log-atom id]
+                           (proxy [org.httpkit.client.HttpClient] []
+                             (exec [url cfg sslengine listener]
+                               (swap! call-log-atom conj {:client-id id :url url})
+                               (proxy-super exec url cfg sslengine listener))))]
+    (testing "client from var root binding"
+      (let [call-log (atom [])]
+        (with-redefs [http/*default-client* (recording-client call-log :var-root)]
+          @(http/get url-1))
+        (is (= [{:client-id :var-root :url url-1}
+                {:client-id :var-root :url url-2}]
+               @call-log))))
+    (testing "client from dynamic binding"
+      (testing "overrides var root binding"
+        (let [call-log (atom [])]
+          (with-redefs [http/*default-client* (recording-client call-log :var-root)]
+            (binding [http/*default-client* (recording-client call-log :binding)]
+              @(http/get url-1)))
+          (is (= [{:client-id :binding :url url-1}
+                  {:client-id :binding :url url-2}]
+                 @call-log)))))
+    (testing "client from request options"
+      (testing "overrides var root binding"
+        (let [call-log (atom [])]
+          (with-redefs [http/*default-client* (recording-client call-log :var-root)]
+            @(http/get url-1 {:client (recording-client call-log :request-opts)}))
+          (is (= [{:client-id :request-opts :url url-1}
+                  {:client-id :request-opts :url url-2}]
+                 @call-log))))
+      (testing "overrides dynamic binding"
+        (let [call-log (atom [])]
+          (binding [http/*default-client* (recording-client call-log :binding)]
+            @(http/get url-1 {:client (recording-client call-log :request-opts)}))
+          (is (= [{:client-id :request-opts :url url-1}
+                  {:client-id :request-opts :url url-2}]
+                 @call-log)))))))
+
 ;; https://github.com/http-kit/http-kit/issues/54
 (deftest test-nested-param
   (let [url "http://localhost:4347/nested-param"

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -369,6 +369,7 @@
                            :keepalive -1
                            :url url3})))))))
 
+;; https://github.com/http-kit/http-kit/pull/464
 (deftest test-redirect-with-client
   (let [url-1 "http://localhost:4347/redirect?total=1&n=0"
         url-2 "http://localhost:4347/redirect?total=1&n=1&code=302"

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -390,18 +390,11 @@
                               (proxy [HttpClient] []
                                 (exec [url cfg sslengine ^IRespListener listener]
                                   (let [blocking-listener (reify IRespListener
-                                                            (onInitialLineReceived [this version status]
-                                                              (.onInitialLineReceived listener version status))
-                                                            (onHeadersReceived [this headers]
-                                                              (.onHeadersReceived listener headers))
-                                                            (onBodyReceived [this buf len]
-                                                              (.onBodyReceived listener buf len))
-                                                            (onCompleted [this]
-                                                              @p
-                                                              (.onCompleted listener))
-                                                            (onThrowable [this t]
-                                                              @p
-                                                              (.onThrowable listener t)))]
+                                                            (onInitialLineReceived [this version status]    (.onInitialLineReceived listener version status))
+                                                            (onHeadersReceived     [this headers]           (.onHeadersReceived     listener headers))
+                                                            (onBodyReceived        [this buf len]           (.onBodyReceived        listener buf len))
+                                                            (onCompleted           [this]                @p (.onCompleted           listener))
+                                                            (onThrowable           [this t]              @p (.onThrowable           listener t)))]
                                     (.exec client url cfg sslengine blocking-listener)))))
               call-log (atom [])
               p (promise)


### PR DESCRIPTION
Thanks, @ptaoussanis @jimpil @fpischedda and all the other contributors, for the SNI fix/workaround -- upgrading to http-kit 2.5.1 and switching to the new `org.httpkit.sni-client/default-client` has been a breeze.

### Issue

I did encounter an unexpected behavior when overriding `*default-client*` with `(binding ,,,)` -- while the client from the dynamic binding is used for the first/initial request, subsequent requests (i.e., for following redirects) use the root binding instead.

I've included a test case here demonstrating the issue, and would be happy to discuss with you all.

### Workaround

The workaround in my case was to specify `:client` in request options _instead_ of using `*default-client*`:

```
(http/get url {:client (force org.httpkit.sni-client/default-client)})
```

### How to address the issue

* I would recommend adding `:client` to request options when following redirects (so the initial request might fetch a client from `*default-client*` but redirects would _always_ include `:client` in the options map.)
* Alternatively, we could make a binding for `(let [,,, bound-request (bound-fn request) ,,,] ,,,)` and use `bound-request` when following redirects.
* Or we could do both.
* I'm happy to update this PR with any of these changes, but I figured it'd be better to confirm the problem and discuss potential solutions here first.

### Improving the tests?

* I believe these tests demonstrate the issue, but they aren't the clearest or most maintainable code.
* If you have any ideas or feedback, please let me know.