### PR TITLE
Fix NPE in sni-client when Java version is just an int

### DIFF
--- a/src/org/httpkit/sni_client.clj
+++ b/src/org/httpkit/sni_client.clj
@@ -21,7 +21,10 @@
       (Integer/parseInt (.substring s 0 dot-idx))
 
       (pos? dash-idx)
-      (Integer/parseInt (.substring s 0 dash-idx)))))
+      (Integer/parseInt (.substring s 0 dash-idx))
+      
+      :else
+      (try (Integer/parseInt s) (catch Exception e)))))
 
 (comment
   (parse-java-version "1.6.0_23") ; 6


### PR DESCRIPTION
I've come across a NullPointerException when using JDK 16, more specifically the first build of JDK 16. There the `java.version` value string is just `"16"` which causes the `parse-java-version` function to return null. This issue will happen for all java version strings that are just plain numbers.