### PR TITLE
Add --initialize-at-run-time to always be present as configuration

### DIFF
--- a/resources/META-INF/native-image/http-kit/http-kit/native-image.properties
+++ b/resources/META-INF/native-image/http-kit/http-kit/native-image.properties
@@ -1,0 +1,1 @@
+Args=--initialize-at-run-time=org.httpkit.client.ClientSslEngineFactory\$SSLHolder


### PR DESCRIPTION
This follows the conversation in #475, to add --initialize-at-run-time setting to native-image configuration so that GRAAL builds would not fail and users would not have to add this flag themselves. 

I tested this locally with a project of mine and seemed to work just fine, but would be nice if someone else could also give it a go. Thank you @borkdude for the solution.