### PR TITLE
Addresses issue #482

### DIFF
--- a/src/org/httpkit/sni_client.clj
+++ b/src/org/httpkit/sni_client.clj
@@ -21,12 +21,18 @@
       (Integer/parseInt (.substring s 0 dot-idx))
 
       (pos? dash-idx)
-      (Integer/parseInt (.substring s 0 dash-idx)))))
+      (Integer/parseInt (.substring s 0 dash-idx))
+
+      :else
+      (Integer/parseInt s))))
 
 (comment
-  (parse-java-version "1.6.0_23") ; 6
-  (parse-java-version "9.0.1")    ; 9
-  (parse-java-version "16-ea")    ; 16
+  (parse-java-version "1.6.0_23")  ; 6
+  (parse-java-version "1.8.0_302") ; 8
+  (parse-java-version "9.0.1")     ; 9
+  (parse-java-version "11.0.12")   ; 11
+  (parse-java-version "16-ea")     ; 16
+  (parse-java-version "17")        ; 17
   )
 
 (def ^:private java-version_


### PR DESCRIPTION
Please note that I had to modify the `./bin/javac` script and set `-target` and `-source` to `1.8` in order to be able to compile and test the code (that change is **not** included in this PR, as it's unrelated to issue #482).

Test results per tested JVM:
* OpenJDK Runtime Environment (Temurin)(build 1.8.0_302-b08): **one test failure** (see below for full output)
* OpenJDK Runtime Environment Temurin-11.0.12+7 (build 11.0.12+7): **zero test failures**
* OpenJDK Runtime Environment Temurin-17+35 (build 17+35): **zero test failures**

Output for failed test on JDK 1.8:

```shell
$ java -version
openjdk version "1.8.0_302"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_302-b08)
OpenJDK 64-Bit Server VM (Temurin)(build 25.302-b08, mixed mode)
$ rake
./scripts/javac with-test && lein test
compile java test code
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Reflection warning, clojure/tools/reader/impl/commons.clj:112:31 - call to method endsWith can't be resolved (target class is unknown).
Performance warning, clj_http/client.clj:454:9 - case has int tests, but tested expression is not primitive.
Reflection warning, ring/util/response.clj:77:3 - call to method startsWith can't be resolved (target class is unknown).
Reflection warning, ring/util/response.clj:288:7 - call to method getResources can't be resolved (target class is unknown).
Reflection warning, ring/util/response.clj:297:37 - reference to field getProtocol can't be resolved.
Reflection warning, ring/util/response.clj:298:27 - call to method startsWith can't be resolved (target class is unknown).
11:40:28.589 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @4562ms
Reflection warning, ring/adapter/jetty.clj:30:3 - call to org.eclipse.jetty.server.ServerConnector ctor can't be resolved.
Reflection warning, crypto/random.clj:28:12 - call to static method encodeHex on org.apache.commons.codec.binary.Hex can't be resolved (argument types: unknown).
Reflection warning, crypto/random.clj:28:3 - call to java.lang.String ctor can't be resolved.
Reflection warning, ring/middleware/basic_authentication.clj:21:40 - reference to field getBytes can't be resolved.
Reflection warning, org/httpkit/client_test.clj:546:49 - reference to field getMessage on java.lang.Object can't be resolved.
Reflection warning, org/httpkit/client_test.clj:547:23 - reference to field getMaximumPoolSize can't be resolved.
Reflection warning, http/async/client/status.clj:23:26 - reference to field getStatusCode can't be resolved.
Reflection warning, http/async/client/status.clj:24:18 - reference to field getStatusText can't be resolved.
Reflection warning, http/async/client/status.clj:25:23 - reference to field getProtocolText can't be resolved.
Reflection warning, http/async/client/status.clj:26:20 - reference to field getProtocolMajorVersion can't be resolved.
Reflection warning, http/async/client/status.clj:27:20 - reference to field getProtocolMinorVersion can't be resolved.
Reflection warning, http/async/client/headers.clj:55:39 - reference to field toLowerCase can't be resolved.
Reflection warning, http/async/client/headers.clj:71:37 - call to method split on java.lang.Object can't be resolved (no such method).
Reflection warning, http/async/client/headers.clj:71:37 - call to method split can't be resolved (target class is unknown).
Reflection warning, http/async/client/util.clj:37:3 - call to method setProxyServer can't be resolved (target class is unknown).
Reflection warning, http/async/client/util.clj:67:5 - call to method setRealm can't be resolved (target class is unknown).
Reflection warning, http/async/client/request.clj:55:5 - reference to field toUpperCase can't be resolved.
Reflection warning, http/async/client/request.clj:74:9 - call to method writeTo can't be resolved (target class is unknown).
Reflection warning, http/async/client/request.clj:138:10 - call to com.ning.http.client.RequestBuilder ctor can't be resolved.
Reflection warning, http/async/client/request.clj:169:35 - call to method getBytes can't be resolved (target class is unknown).
Reflection warning, http/async/client/request.clj:169:21 - call to method setBody on ahc.RequestBuilderWrapper can't be resolved (argument types: unknown).
Reflection warning, http/async/client/request.clj:173:35 - call to method setBody on ahc.RequestBuilderWrapper can't be resolved (argument types: java.lang.Object).
Reflection warning, http/async/client/request.clj:174:28 - call to method setBody on ahc.RequestBuilderWrapper can't be resolved (argument types: java.lang.Object).
Reflection warning, http/async/client/request.clj:179:25 - call to method addBodyPart on com.ning.http.client.RequestBuilder can't be resolved (argument types: unknown).
Reflection warning, http/async/client/request.clj:179:25 - call to method addBodyPart on com.ning.http.client.RequestBuilder can't be resolved (argument types: unknown).
Reflection warning, http/async/client/request.clj:239:9 - call to method executeRequest can't be resolved (target class is unknown).
Reflection warning, http/async/client/request.clj:286:41 - reference to field isCancelled can't be resolved.
Reflection warning, http/async/client/request.clj:287:37 - call to method cancel can't be resolved (target class is unknown).
Reflection warning, http/async/client.clj:225:19 - reference to field take can't be resolved.
Reflection warning, http/async/client.clj:228:17 - call to method put can't be resolved (target class is unknown).
Reflection warning, http/async/client.clj:234:3 - call to method toString on java.io.ByteArrayOutputStream can't be resolved (argument types: unknown).
Reflection warning, http/async/client.clj:405:11 - call to method executeRequest can't be resolved (target class is unknown).
Reflection warning, http/async/client.clj:405:5 - reference to field get can't be resolved.
Reflection warning, org/httpkit/ws_test.clj:43:54 - call to java.lang.String ctor can't be resolved.
Reflection warning, org/httpkit/ws_test.clj:43:54 - call to java.lang.String ctor can't be resolved.
Reflection warning, org/httpkit/server_test.clj:101:14 - call to static method valueOf on java.lang.Integer can't be resolved (argument types: unknown).

lein test org.httpkit.client-proxy-test
11:40:29.922 [main] INFO  org.eclipse.jetty.server.Server - jetty-9.2.10.v20150310
11:40:30.161 [main] INFO  org.eclipse.jetty.server.ServerConnector - Started ServerConnector@8d0d52a{SSL-http/1.1}{0.0.0.0:9898}
11:40:30.162 [main] INFO  org.eclipse.jetty.server.Server - Started @6136ms
11:40:30.162 [main] INFO  org.eclipse.jetty.server.Server - jetty-9.2.10.v20150310
11:40:30.168 [main] INFO  org.eclipse.jetty.server.ServerConnector - Started ServerConnector@775429c8{SSL-http/1.1}{0.0.0.0:9899}
11:40:30.168 [main] INFO  org.eclipse.jetty.server.Server - Started @6143ms
{:remote-addr 127.0.0.1, :headers {accept-encoding gzip, deflate, content-length 0, host 127.0.0.1:9898, proxy-connection Keep-Alive, user-agent http-kit/2.0}, :async-channel #object[org.httpkit.server.AsyncChannel 0x53961a03 /127.0.0.1:4348<->/127.0.0.1:57477], :server-port 9898, :content-length 0, :websocket? false, :content-type nil, :character-encoding utf8, :uri https://127.0.0.1:9898/get, :server-name 127.0.0.1, :query-string nil, :body nil, :scheme :http, :request-method :get}
https://127.0.0.1:9898 https://127.0.0.1:9898/get nil
{:remote-addr 127.0.0.1, :headers {accept-encoding gzip, deflate, connection close, host 127.0.0.1:4347, proxy-connection Keep-Alive, user-agent Apache-HttpClient/4.5.10 (Java/1.8.0_302)}, :async-channel #object[org.httpkit.server.AsyncChannel 0x34976f00 /127.0.0.1:4348<->/127.0.0.1:57479], :server-port 4347, :content-length 0, :websocket? false, :content-type nil, :character-encoding utf8, :uri http://127.0.0.1:4347/get, :server-name 127.0.0.1, :query-string nil, :body nil, :scheme :http, :request-method :get}
http://127.0.0.1:4347 http://127.0.0.1:4347/get nil
{:remote-addr 127.0.0.1, :headers {accept-encoding gzip, deflate, content-length 0, host 127.0.0.1:4347, proxy-connection Keep-Alive, user-agent http-kit/2.0}, :async-channel #object[org.httpkit.server.AsyncChannel 0x53961a03 /127.0.0.1:4348<->/127.0.0.1:57477], :server-port 4347, :content-length 0, :websocket? false, :content-type nil, :character-encoding utf8, :uri http://127.0.0.1:4347/get, :server-name 127.0.0.1, :query-string nil, :body nil, :scheme :http, :request-method :get}
http://127.0.0.1:4347 http://127.0.0.1:4347/get nil
{:remote-addr 127.0.0.1, :headers {accept-encoding gzip, deflate, content-length 0, host 127.0.0.1:4347, proxy-connection Keep-Alive, user-agent http-kit/2.0}, :async-channel #object[org.httpkit.server.AsyncChannel 0x53961a03 /127.0.0.1:4348<->/127.0.0.1:57477], :server-port 4347, :content-length 0, :websocket? false, :content-type nil, :character-encoding utf8, :uri http://127.0.0.1:4347/get, :server-name 127.0.0.1, :query-string nil, :body nil, :scheme :http, :request-method :get}
http://127.0.0.1:4347 http://127.0.0.1:4347/get nil
{:remote-addr 127.0.0.1, :headers {accept-encoding gzip, deflate, content-length 0, host 127.0.0.1:4347, proxy-connection Keep-Alive, user-agent http-kit/2.0}, :async-channel #object[org.httpkit.server.AsyncChannel 0x53961a03 /127.0.0.1:4348<->/127.0.0.1:57477], :server-port 4347, :content-length 0, :websocket? false, :content-type nil, :character-encoding utf8, :uri http://127.0.0.1:4347/get, :server-name 127.0.0.1, :query-string nil, :body nil, :scheme :http, :request-method :get}
http://127.0.0.1:4347 http://127.0.0.1:4347/get nil
{:basic-authentication true, :remote-addr 127.0.0.1, :headers {accept-encoding gzip, deflate, authorization Basic dXNlcjpwYXNz, content-length 0, host 127.0.0.1:4347, proxy-connection Keep-Alive, user-agent http-kit/2.0}, :async-channel #object[org.httpkit.server.AsyncChannel 0x6cd8d064 /127.0.0.1:4349<->/127.0.0.1:57484], :server-port 4347, :content-length 0, :websocket? false, :content-type nil, :character-encoding utf8, :uri http://127.0.0.1:4347/get, :server-name 127.0.0.1, :query-string nil, :body nil, :scheme :http, :request-method :get}
http://127.0.0.1:4347 http://127.0.0.1:4347/get nil
{:ssl-client-cert nil, :protocol HTTP/1.1, :remote-addr 127.0.0.1, :headers {user-agent http-kit/2.0, host 127.0.0.1:9898, accept-encoding gzip, deflate, proxy-connection Keep-Alive, content-length 0}, :server-port 9898, :content-length 0, :content-type nil, :character-encoding nil, :uri /get, :server-name 127.0.0.1, :query-string nil, :body #object[org.eclipse.jetty.server.HttpInputOverHTTP 0x786f7ffd HttpInputOverHTTP@786f7ffd], :scheme :https, :request-method :get}
https://127.0.0.1:9898 /get nil
{:ssl-client-cert nil, :protocol HTTP/1.1, :remote-addr 127.0.0.1, :headers {user-agent http-kit/2.0, host 127.0.0.1:4347, accept-encoding gzip, deflate, proxy-connection Keep-Alive, content-length 0}, :server-port 4347, :content-length 0, :content-type nil, :character-encoding nil, :uri /get, :server-name 127.0.0.1, :query-string nil, :body #object[org.eclipse.jetty.server.HttpInputOverHTTP 0x36df40e5 HttpInputOverHTTP@36df40e5], :scheme :https, :request-method :get}
http://127.0.0.1:4347 /get nil
11:40:30.655 [main] INFO  org.eclipse.jetty.server.ServerConnector - Stopped ServerConnector@8d0d52a{SSL-http/1.1}{0.0.0.0:9898}
11:40:30.657 [main] INFO  org.eclipse.jetty.server.ServerConnector - Stopped ServerConnector@775429c8{SSL-http/1.1}{0.0.0.0:9899}

lein test org.httpkit.client-test
11:40:30.660 [main] INFO  org.eclipse.jetty.server.Server - jetty-9.2.10.v20150310
11:40:30.663 [main] INFO  org.eclipse.jetty.server.ServerConnector - Started ServerConnector@7375e6c1{HTTP/1.1}{0.0.0.0:14347}
11:40:30.665 [main] INFO  org.eclipse.jetty.server.ServerConnector - Started ServerConnector@596c6c3e{SSL-http/1.1}{0.0.0.0:9898}
11:40:30.665 [main] INFO  org.eclipse.jetty.server.Server - Started @6640ms
Tue Sep 28 11:40:35 PDT 2021 [client-loop#2] ERROR - select exception, should not happen
java.lang.IllegalStateException: Client/Server mode has not yet been set.
	at sun.security.ssl.SSLEngineImpl.beginHandshake(SSLEngineImpl.java:92)
	at org.httpkit.client.HttpClient.finishConnect(HttpClient.java:412)
	at org.httpkit.client.HttpClient.run(HttpClient.java:492)
	at java.lang.Thread.run(Thread.java:748)

lein test :only org.httpkit.client-test/test-default-sni-client

FAIL in (test-default-sni-client) (client_test.clj:337)
`sni/default-client` behaves similarly to `URL.openStream()`
expected: (nil?
           (:error
            @(http/request
              {:client https-client,
               :sslengine sslengine,
               :keepalive -1,
               :url url0})))
  actual: (not (nil? #error {
 :cause "Client/Server mode has not yet been set."
 :via
 [{:type java.lang.IllegalStateException
   :message "Client/Server mode has not yet been set."
   :at [sun.security.ssl.SSLEngineImpl wrap "SSLEngineImpl.java" 119]}]
 :trace
 [[sun.security.ssl.SSLEngineImpl wrap "SSLEngineImpl.java" 119]
  [sun.security.ssl.SSLEngineImpl wrap "SSLEngineImpl.java" 110]
  [javax.net.ssl.SSLEngine wrap "SSLEngine.java" 511]
  [org.httpkit.client.HttpsRequest wrapRequest "HttpsRequest.java" 58]
  [org.httpkit.client.HttpsRequest doHandshake "HttpsRequest.java" 128]
  [org.httpkit.client.HttpClient doWrite "HttpClient.java" 262]
  [org.httpkit.client.HttpClient run "HttpClient.java" 496]
  [java.lang.Thread run "Thread.java" 748]]}))
Tue Sep 28 11:40:35 PDT 2021 [client-loop#2] ERROR - select exception, should not happen
java.lang.IllegalStateException: Client/Server mode has not yet been set.
	at sun.security.ssl.SSLEngineImpl.beginHandshake(SSLEngineImpl.java:92)
	at org.httpkit.client.HttpClient.finishConnect(HttpClient.java:412)
	at org.httpkit.client.HttpClient.run(HttpClient.java:492)
	at java.lang.Thread.run(Thread.java:748)
Tue Sep 28 11:40:35 PDT 2021 [client-loop#2] ERROR - select exception, should not happen
java.lang.IllegalStateException: Client/Server mode has not yet been set.
	at sun.security.ssl.SSLEngineImpl.beginHandshake(SSLEngineImpl.java:92)
	at org.httpkit.client.HttpClient.finishConnect(HttpClient.java:412)
	at org.httpkit.client.HttpClient.run(HttpClient.java:492)
	at java.lang.Thread.run(Thread.java:748)
Tue Sep 28 11:40:40 PDT 2021 [client-worker-16] ERROR - GET badurl's callback
java.lang.Exception: http-kit client deadlock-guard: refusing to deref a request callback from inside a callback. This feature can be disabled with the request's `:deadlock-guard?` option.
	at org.httpkit.client$deadlock_guard$e__5934.invoke(client.clj:171)
	at org.httpkit.client$deadlock_guard$reify__5936.deref(client.clj:176)
	at clojure.core$deref.invokeStatic(core.clj:2228)
	at clojure.core$deref.invoke(core.clj:2214)
	at org.httpkit.client_test$fn__9964$bad_callback__9965.invoke(client_test.clj:540)
	at org.httpkit.client_test$fn__9964$bad_callback__9965$fn__9966.invoke(client_test.clj:544)
	at org.httpkit.client$request$deliver_resp__5945$fn__5946.invoke(client.clj:247)
	at org.httpkit.client$request$deliver_resp__5945.invoke(client.clj:245)
	at org.httpkit.client$request$reify__5950.onThrowable(client.clj:282)
	at org.httpkit.client.Handler.run(RespListener.java:40)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Tue Sep 28 11:40:40 PDT 2021 [client-worker-8] ERROR - GET http://127.0.0.1:4347/get's callback
java.lang.Exception: Exception
	at org.httpkit.client_test$fn__8692$fn__8863$fn__8865.invoke(client_test.clj:154)
	at org.httpkit.client$request$deliver_resp__5945$fn__5946.invoke(client.clj:247)
	at org.httpkit.client$request$deliver_resp__5945.invoke(client.clj:245)
	at org.httpkit.client$request$reify__5950.onSuccess(client.clj:277)
	at org.httpkit.client.Handler.run(RespListener.java:42)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Tue Sep 28 11:40:40 PDT 2021 [client-worker-4] ERROR - GET http://127.0.0.1:4347/get's callback
java.lang.Throwable: Throwable
	at org.httpkit.client_test$fn__8692$fn__8863$fn__8875.invoke(client_test.clj:158)
	at org.httpkit.client$request$deliver_resp__5945$fn__5946.invoke(client.clj:247)
	at org.httpkit.client$request$deliver_resp__5945.invoke(client.clj:245)
	at org.httpkit.client$request$reify__5950.onSuccess(client.clj:277)
	at org.httpkit.client.Handler.run(RespListener.java:42)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Tue Sep 28 11:40:40 PDT 2021 [client-worker-3] ERROR - GET http://127.0.0.1:14347/get's callback
java.lang.Exception: Exception
	at org.httpkit.client_test$fn__8692$fn__8863$fn__8865.invoke(client_test.clj:154)
	at org.httpkit.client$request$deliver_resp__5945$fn__5946.invoke(client.clj:247)
	at org.httpkit.client$request$deliver_resp__5945.invoke(client.clj:245)
	at org.httpkit.client$request$reify__5950.onSuccess(client.clj:277)
	at org.httpkit.client.Handler.run(RespListener.java:42)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Tue Sep 28 11:40:40 PDT 2021 [client-worker-9] ERROR - GET http://127.0.0.1:14347/get's callback
java.lang.Throwable: Throwable
	at org.httpkit.client_test$fn__8692$fn__8863$fn__8875.invoke(client_test.clj:158)
	at org.httpkit.client$request$deliver_resp__5945$fn__5946.invoke(client.clj:247)
	at org.httpkit.client$request$deliver_resp__5945.invoke(client.clj:245)
	at org.httpkit.client$request$reify__5950.onSuccess(client.clj:277)
	at org.httpkit.client.Handler.run(RespListener.java:42)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
11:40:40.680 [main] INFO  org.eclipse.jetty.server.ServerConnector - Stopped ServerConnector@7375e6c1{HTTP/1.1}{0.0.0.0:14347}
11:40:40.681 [main] INFO  org.eclipse.jetty.server.ServerConnector - Stopped ServerConnector@596c6c3e{SSL-http/1.1}{0.0.0.0:9898}

lein test org.httpkit.num-connections

lein test org.httpkit.server-test
Sep 28, 2021 11:40:42 AM org.apache.http.impl.execchain.RetryExec execute
INFO: I/O exception (org.apache.http.NoHttpResponseException) caught when processing request to {}->http://localhost:3474: The target server failed to respond
Sep 28, 2021 11:40:42 AM org.apache.http.impl.execchain.RetryExec execute
INFO: Retrying request to {}->http://localhost:3474
Sep 28, 2021 11:40:43 AM org.apache.http.impl.execchain.RetryExec execute
INFO: I/O exception (org.apache.http.NoHttpResponseException) caught when processing request to {}->http://localhost:3474: The target server failed to respond
Sep 28, 2021 11:40:43 AM org.apache.http.impl.execchain.RetryExec execute
INFO: Retrying request to {}->http://localhost:3474

lein test org.httpkit.utils-test

lein test org.httpkit.ws-test

Ran 91 tests containing 6941 assertions.
1 failures, 0 errors.
Tests failed.
rake aborted!
Command failed with status (1): [./scripts/javac with-test && lein test...]
/Users/pmonks/Development/personal/http-kit/Rakefile:5:in `block in <top (required)>'
/Library/Ruby/Gems/2.6.0/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```