### PR TITLE
Add :start-time to request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml*
 /target
 /.idea
 /_site
+.cpcache

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:paths       ["src" "target/classes"]
+ :deps        {}
+ }

--- a/deps.edn
+++ b/deps.edn
@@ -1,3 +1,2 @@
 {:paths       ["src" "target/classes"]
- :deps        {}
- }
+ :deps        {org.clojure/clojure {:mvn/version "1.10.3"}}}

--- a/scripts/javac
+++ b/scripts/javac
@@ -3,7 +3,7 @@
 rm -rf target && mkdir -p target/classes
 
 CP=`lein classpath`
-find src/java -name "*.java" | xargs javac -Xlint:unchecked -g -target 1.6 -source 1.6 -encoding utf8 -cp $CP -d target/classes -sourcepath src/java/
+find src/java -name "*.java" | xargs javac -Xlint:unchecked -g  -encoding utf8 -cp $CP -d target/classes -sourcepath src/java/
 
 if [ $# -gt 0 ]; then
     # lein test need it

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -27,6 +27,7 @@ public class AsyncChannel {
 
     private final SelectionKey key;
     private final HttpServer server;
+    public long createdAt;
 
     final public AtomicBoolean closedRan = new AtomicBoolean();
     final private AtomicReference<IFn> closeHandler = new AtomicReference<>(null);
@@ -49,6 +50,7 @@ public class AsyncChannel {
     }
 
     public void reset(HttpRequest request) {
+        this.createdAt = System.currentTimeMillis();
         this.request = request;
         serialTask = null;
 

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -27,7 +27,6 @@ public class AsyncChannel {
 
     private final SelectionKey key;
     private final HttpServer server;
-    public long createdAt;
 
     final public AtomicBoolean closedRan = new AtomicBoolean();
     final private AtomicReference<IFn> closeHandler = new AtomicReference<>(null);
@@ -50,7 +49,6 @@ public class AsyncChannel {
     }
 
     public void reset(HttpRequest request) {
-        this.createdAt = System.currentTimeMillis();
         this.request = request;
         serialTask = null;
 

--- a/src/java/org/httpkit/server/HttpRequest.java
+++ b/src/java/org/httpkit/server/HttpRequest.java
@@ -26,6 +26,7 @@ public class HttpRequest {
     String charset = "utf8";
     boolean isKeepAlive = false;
     boolean isWebSocket = false;
+    long startTime;
 
     InetSocketAddress remoteAddr;
     AsyncChannel channel;
@@ -41,6 +42,10 @@ public class HttpRequest {
             uri = url;
             queryString = null;
         }
+    }
+
+    public void setStartTime(long time) {
+        this.startTime = time;
     }
 
     public InputStream getBody() {

--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -177,8 +177,9 @@ public class HttpServer implements Runnable {
                     if (status.get() != Status.RUNNING) {
                         request.isKeepAlive = false;
                     }
-
+                    request.setStartTime(System.currentTimeMillis());
                     channel.reset(request);
+
                     if (request.isWebSocket) {
                         key.attach(new WsAtta(channel, maxWs));
                     } else {

--- a/src/java/org/httpkit/server/RingHandler.java
+++ b/src/java/org/httpkit/server/RingHandler.java
@@ -51,6 +51,7 @@ class ClojureRing {
     static final Keyword BODY = intern("body");
     static final Keyword WEBSOCKET = intern("websocket?");
     static final Keyword ASYC_CHANNEL = intern("async-channel");
+    static final Keyword START_TIME = intern("start-time");
 
     static final Keyword HTTP = intern("http");
 
@@ -81,6 +82,7 @@ class ClojureRing {
             .assoc(ASYC_CHANNEL, req.channel)
             .assoc(WEBSOCKET, req.isWebSocket)
             .assoc(REQUEST_METHOD, req.method.KEY)
+            .assoc(START_TIME, req.startTime)
 
             // key is already lower cased, required by ring spec
             .assoc(HEADERS, PersistentArrayMap.create(req.headers))


### PR DESCRIPTION
For monitoring http-kit based applications we need to track time spent in queue and estimate full request time.
This PR adds startTime to request, which is set on `doRead` - not sure this is the right place to do it.