### PR TITLE
Add HTTP LIST method

### DIFF
--- a/src/java/org/httpkit/HttpMethod.java
+++ b/src/java/org/httpkit/HttpMethod.java
@@ -9,9 +9,9 @@ public enum HttpMethod {
     GET(intern("get")), HEAD(intern("head")), POST(intern("post")), PUT(intern("put")),
     DELETE(intern("delete")), TRACE(intern("trace")), OPTIONS(intern("options")),
     CONNECT(intern("connect")), PATCH(intern("patch")), PROPFIND(intern("propfind")),
-	PROPPATCH(intern("proppatch")), LOCK(intern("lock")), UNLOCK(intern("unlock")),
-	REPORT(intern("report")), ACL(intern("acl")), MOVE(intern("move")), 
-	COPY(intern("copy")), MKCOL(intern("mkcol"));
+    PROPPATCH(intern("proppatch")), LOCK(intern("lock")), UNLOCK(intern("unlock")),
+    REPORT(intern("report")), ACL(intern("acl")), MOVE(intern("move")),
+    COPY(intern("copy")), MKCOL(intern("mkcol")), LIST(intern("list"));
 
     public final Keyword KEY;
 


### PR DESCRIPTION
Hello! I maintain the [amperity/vault-clj](https://github.com/amperity/vault-clj) project, which recently switched to using http-kit so that the project is friendly for Graal compilation. I've been working on rewriting the library and extending the APIs it supports, and one thing I noticed is that [Vault](https://www.vaultproject.io/) has several APIs which use the non-standard `LIST` method. Trying to use this with http-kit throws an error right now, since the methods have to be explicitly listed in the `HttpMethod` enum.

This PR adds the `LIST` method to the enum. I ran `lein check` and `lein test` locally - the instructions around the `Rakefile` and the related scripts seem... very out of date. I'm consistently getting a failure in an HTTPS test timeout, but I don't see how that could be related to my changes. 🤔 

```
lein test :only org.httpkit.client-test/test-misc-https-certs              
                                                                                                           
FAIL in (test-misc-https-certs) (client_test.clj:322)                                       
expected: (contains? @(http/get "https://apple.com") :status)                
  actual: (not                                                                                             
           (contains?                                                                                      
            {:opts {:method :get, :url "https://apple.com"},
             :error #error {                                                                               
 :cause "idle timeout: 60000ms"
 :via                                                                                                      
 [{:type org.httpkit.client.TimeoutException                                                               
   :message "idle timeout: 60000ms"                                                                        
   :at [org.httpkit.client.HttpClient clearTimeout "HttpClient.java" 134]}]
```
Any pointers would be appreciated, if you think the failure is relevant.