### PR TITLE
properly unrecycle the req when kept-alive conn wasn't able to be reused

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -164,12 +164,7 @@ public class HttpClient implements Runnable {
         keepalives.remove(key);
         // keep-alived connection, remote server close it without sending byte
         if (req.isReuseConn && req.decoder.state == READ_INITIAL) {
-            for (ByteBuffer b : req.request) {
-                b.position(0); // reset for retry
-            }
-            req.isReuseConn = false;
-            req.setConnected(false); // "un"-connect this request if the keepalive conn wasn't able to be reused
-            requests.remove(req); // remove from timeout queue
+            req.unrecycle();
             pending.offer(req); // queue for retry
             selector.wakeup();
             return true; // retry: re-open a connection to server, sent the request again
@@ -425,17 +420,15 @@ public class HttpClient implements Runnable {
                 if (con != null) { // keep alive
                     SelectionKey key = con.key;
                     if (key.isValid()) {
-                        job.isReuseConn = true;
                         // reuse key, engine
                         try {
                             job.recycle((Request) key.attachment());
                             key.attach(job);
                             key.interestOps(OP_WRITE);
-                            requests.offer(job);
-                            job.setConnected(true); // since we're re-using a keepalive conn, set the timeout as if we're already connected
                             pending.poll();
                             return;
                         } catch (SSLException e) {
+                            job.unrecycle();
                             closeQuietly(key); // https wrap SSLException, start from fresh
                         }
                     } else {
@@ -454,13 +447,13 @@ public class HttpClient implements Runnable {
                       ch.bind(bindAddress);
                     }
                     ch.configureBlocking(false);
+                    // save key for timeout check
+                    requests.offer(job);
                     boolean connected = ch.connect(job.addr);
                     job.setConnected(connected);
                     numConnections++;
                     // if connection is established immediatelly, should wait for write. Fix #98
                     job.key = ch.register(selector, connected ? OP_WRITE : OP_CONNECT, job);
-                    // save key for timeout check
-                    requests.offer(job);
                 } catch (IOException e) {
                     job.finish(e);
                     // HttpUtils.printError("Try to connect " + job.addr, e);

--- a/src/java/org/httpkit/client/HttpsRequest.java
+++ b/src/java/org/httpkit/client/HttpsRequest.java
@@ -19,9 +19,11 @@ public class HttpsRequest extends Request {
                         PriorityQueue<Request> clients, RequestConfig config, SSLEngine engine) {
         super(addr, request, handler, clients, config);
         this.engine = engine;
+        this.engineOriginal = engine;
     }
 
     SSLEngine engine; // package private
+    SSLEngine engineOriginal;
     private ByteBuffer myNetData = ByteBuffer.allocate(40 * 1024);
     private ByteBuffer peerNetData = ByteBuffer.allocate(40 * 1024);
     boolean handshaken = false;
@@ -137,5 +139,15 @@ public class HttpsRequest extends Request {
         this.engine = ((HttpsRequest) old).engine;
         this.handshaken = true;
         wrapRequest(); // prepare for write
+    }
+
+    // if we weren't able to reuse the kept-alive conn, switch back to original ssl engine
+    @Override
+    public void unrecycle() {
+        super.unrecycle();
+        this.engine = this.engineOriginal;
+        this.handshaken = false;
+        myNetData.clear();
+        peerNetData.clear();
     }
 }

--- a/src/java/org/httpkit/client/Request.java
+++ b/src/java/org/httpkit/client/Request.java
@@ -90,6 +90,18 @@ public class Request implements Comparable<Request> {
 
     public void recycle(Request old) throws SSLException {
         this.key = old.key;
+        isReuseConn = true;
+        clients.offer(this);
+        setConnected(true); // since we're re-using a keepalive conn, set the timeout as if we're already connected
+    }
+
+    public void unrecycle() {
+        for (ByteBuffer b : request) {
+            b.position(0); // reset for retry
+        }
+        isReuseConn = false;
+        setConnected(false);
+        clients.remove(this); // setConnected adds to timeouts queue, but we shouldn't time this out anymore
     }
 }
 


### PR DESCRIPTION
- Fixes the SSLProtocolException "Input record too big" errors reported in #469. This is a pretty bad bug. More details [here](https://github.com/http-kit/http-kit/issues/469#issuecomment-1136477850).
- Moves more logic into recycle/unrecycle to make them symmetric.
- Fixes potential bug where req was getting added to requests queue too many times.