### PR TITLE
add :as :raw-byte-array coercion for babashka use case

### DIFF
--- a/src/java/org/httpkit/DynamicBytes.java
+++ b/src/java/org/httpkit/DynamicBytes.java
@@ -73,4 +73,13 @@ public class DynamicBytes {
         byte[] bs = str.getBytes(c);
         return append(bs, bs.length);
     }
+
+    /**
+     * get the underlying bytes, copied
+     *
+     * @return
+     */
+    public byte[] bytes() {
+        return Arrays.copyOf(data, idx);
+    }
 }

--- a/src/java/org/httpkit/client/RespListener.java
+++ b/src/java/org/httpkit/client/RespListener.java
@@ -127,8 +127,9 @@ public class RespListener implements IRespListener {
             return;
         }
         try {
-            if (coercion == 0) {
-                pool.submit(new Handler(handler, status.getCode(), headers, body));
+            if (coercion == 0 || coercion == 5) { // 0=> none, 5=> raw-byte-array
+                Object b = coercion == 0 ? body : body.bytes();
+                pool.submit(new Handler(handler, status.getCode(), headers, b));
                 return;
             }
             DynamicBytes bytes = unzipBody();

--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -214,6 +214,8 @@ an SNI-capable one, e.g.:
   (request {:url \"http://site.com/string.txt\" :as :text})
   ;; Try to automatically coerce the output based on the content-type header, currently supports :text :stream, (with automatic charset detection)
   (request {:url \"http://site.com/string.txt\" :as :auto})
+  ;; return the body as is with no unzipping or coercion whatsoever. return as byte[]
+  (request {:url \"http://site.com/favicon.ico\" :as :raw-byte-array})
   ;; return the body as is with no unzipping or coercion whatsoever. returns as org.httpkit.DynamicBytes
   (request {:url \"http://site.com/favicon.ico\" :as :none})
 
@@ -282,9 +284,9 @@ an SNI-capable one, e.g.:
                   (onThrowable [this t]
                     (deliver-resp {:opts opts :error t})))
         listener (RespListener. handler filter worker-pool
-                                ;; 0 will return as DynamicBytes - i.e. you will need to handle unzip yourself
-                                ;; otherwise, there are 4 coercions supported for now
-                                (case as :none 0 :auto 1 :text 2 :stream 3 :byte-array 4))
+                                ;; 0 will return as DynamicBytes and 5 returns bytes[] - i.e. you will need to handle unzip yourself
+                                ;; otherwise, there are 5 coercions supported for now
+                                (case as :none 0 :auto 1 :text 2 :stream 3 :byte-array 4 :raw-byte-array 5))
         effective-proxy-url (if proxy-host (str proxy-host ":" proxy-port) proxy-url)
         connect-timeout (or timeout connect-timeout)
         idle-timeout    (or timeout idle-timeout)


### PR DESCRIPTION
Fixes #400 
The workaround presented  [here](https://github.com/http-kit/http-kit/issues/400#issuecomment-896372589) works for the JVM but not in babashka. Currently babashka does not make `DynamicBytes` available for Java interop. 