### PR TITLE
Websocket fix

### DIFF
--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -456,7 +456,7 @@ public class HttpUtils {
                     // trust the computed length
                     headers.putOrReplace(
                         CONTENT_LENGTH,
-                        (bodyBuffer != null) ? Integer.toString(bodyBuffer.remaining()) : "0");
+                        (bodyBuffer != null)) Integer.toString(bodyBuffer.remaining()) : "0");
                 }
             }
         } catch (IOException e) {

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -452,11 +452,11 @@ public class HttpUtils {
             bodyBuffer = bodyBuffer(body);
             // only write length if not chunked
             if (!CHUNKED.equals(headers.get("Transfer-Encoding"))) {
-                if (bodyBuffer != null) {
+                if ((status / 100) != 1 && status != 204) {
                     // trust the computed length
-                    headers.putOrReplace(CONTENT_LENGTH, Integer.toString(bodyBuffer.remaining()));
-                } else if ((status / 100) != 1 && status != 204) {
-                    headers.putOrReplace(CONTENT_LENGTH, "0");
+                    headers.putOrReplace(
+                        CONTENT_LENGTH,
+                        (bodyBuffer != null)) Integer.toString(bodyBuffer.remaining()) : "0");
                 }
             }
         } catch (IOException e) {

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -452,11 +452,11 @@ public class HttpUtils {
             bodyBuffer = bodyBuffer(body);
             // only write length if not chunked
             if (!CHUNKED.equals(headers.get("Transfer-Encoding"))) {
-                if ((status / 100) != 1 && status != 204) {
+                if (bodyBuffer != null) {
                     // trust the computed length
-                    headers.putOrReplace(
-                        CONTENT_LENGTH,
-                        (bodyBuffer != null)) Integer.toString(bodyBuffer.remaining()) : "0");
+                    headers.putOrReplace(CONTENT_LENGTH, Integer.toString(bodyBuffer.remaining()));
+                } else if ((status / 100) != 1 && status != 204) {
+                    headers.putOrReplace(CONTENT_LENGTH, "0");
                 }
             }
         } catch (IOException e) {

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -456,7 +456,7 @@ public class HttpUtils {
                     // trust the computed length
                     headers.putOrReplace(
                         CONTENT_LENGTH,
-                        (bodyBuffer != null)) Integer.toString(bodyBuffer.remaining()) : "0");
+                        (bodyBuffer != null) ? Integer.toString(bodyBuffer.remaining()) : "0");
                 }
             }
         } catch (IOException e) {

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -455,7 +455,7 @@ public class HttpUtils {
                 if (bodyBuffer != null) {
                     // trust the computed length
                     headers.putOrReplace(CONTENT_LENGTH, Integer.toString(bodyBuffer.remaining()));
-                } else {
+                } else if ((status / 100) != 1 && status != 204) {
                     headers.putOrReplace(CONTENT_LENGTH, "0");
                 }
             }


### PR DESCRIPTION
A fix to the Websocket terminating due to having `Content-Length: 0` in the header, when the application is deployed to Azure App Service. Detailed description can be found at: https://github.com/http-kit/http-kit/issues/498

According to RFC 7230:
```
   A server MUST NOT send a Content-Length header field in any response
   with a status code of 1xx (Informational) or 204 (No Content).  ...
```

In this fix, we check status code passed to `org.httpkit.HttpEncode` and skips adding the content-length header if the status is either `1xx` or `204`.
