### PR TITLE
properly close sockets when calling stop() on client

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -503,6 +503,9 @@ public class HttpClient implements Runnable {
     public void stop() throws IOException {
         running = false;
         if (selector != null) {
+            for (SelectionKey selectionKey : selector.keys()) {
+                selectionKey.channel().close();
+            }
             selector.close();
         }
     }


### PR DESCRIPTION
When the stop() method is called on the client this stops the client-loop thread and closes the selector however this is not enough to actually close the sockets being used by the client. There are usually sockets left open when using keep-alive.

This is not usually an issue when using the http-kit client on a standalone process as the socket gets killed by the OS when the jvm is shutdown, however in a J2EE/Servlet container where an application can be restarted without stopping the JVM this can leave behind an open connection. This connection is usually eventually cleaned up by a full GC but this PR is a simple change which just cleanly closes the sockets that the http-client is using when the stop() method is called.