### PR TITLE
Add clj-kondo support to with-channel

### DIFF
--- a/resources/clj-kondo.exports/http-kit/http-kit/config.edn
+++ b/resources/clj-kondo.exports/http-kit/http-kit/config.edn
@@ -1,0 +1,3 @@
+
+{:hooks
+ {:analyze-call {org.httpkit.server/with-channel httpkit.with-channel/with-channel}}}

--- a/resources/clj-kondo.exports/http-kit/http-kit/httpkit/with_channel.clj
+++ b/resources/clj-kondo.exports/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,0 +1,31 @@
+
+(ns httpkit.with-channel
+  (:require [clj-kondo.hooks-api :as api])
+  )
+
+(defn with-channel [{node :node}]
+
+  (let [[request channel & body] (rest (:children node))]
+
+    (when-not (and request channel)
+      (throw (ex-info "No request or channel provided" {})))
+
+    (when-not (api/token-node? channel)
+      (throw (ex-info "Missing channel argument" {})))
+
+
+    (let [new-node
+          (api/list-node
+           (list*
+            (api/token-node 'let)
+            (api/vector-node [channel (api/vector-node [])])
+            request
+            body
+            ))
+          ]
+
+      {:node new-node}
+      )
+    )
+
+  )


### PR DESCRIPTION
The macro `with-channel` does not play very well with clj-kondo by default. By adding a hook and a config edn file it is possible to get better linting with it.

It currently reports the channel symbol as unresolved.
![image](https://user-images.githubusercontent.com/55855728/220003054-dae435f7-f162-4844-a7b7-5d5703894855.png)

But it is possible to treat it as a proper declaration with the provided changes:
![image](https://user-images.githubusercontent.com/55855728/220003470-96fd5228-8872-4ff4-ab85-67aeef5f083f.png)
