### PR TITLE
Add support for customizing address and channel providers

### DIFF
--- a/src/java/org/httpkit/client/HttpsRequest.java
+++ b/src/java/org/httpkit/client/HttpsRequest.java
@@ -7,7 +7,7 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
 import java.io.IOException;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
@@ -15,7 +15,7 @@ import java.nio.channels.SocketChannel;
 public class HttpsRequest extends Request {
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
-    public HttpsRequest(InetSocketAddress addr, String host, ByteBuffer[] request, IRespListener handler,
+    public HttpsRequest(SocketAddress addr, String host, ByteBuffer[] request, IRespListener handler,
                         PriorityQueue<Request> clients, RequestConfig config, SSLEngine engine) {
         super(addr, host, request, handler, clients, config);
         this.engine = engine;

--- a/src/java/org/httpkit/client/PersistentConn.java
+++ b/src/java/org/httpkit/client/PersistentConn.java
@@ -1,15 +1,15 @@
 package org.httpkit.client;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
 
 public class PersistentConn implements Comparable<PersistentConn> {
     private final long timeoutTs;
     private final String host;
-    public final InetSocketAddress addr;
+    public final SocketAddress addr;
     public final SelectionKey key;
 
-    public PersistentConn(long timeoutTs, InetSocketAddress addr, String host, SelectionKey key) {
+    public PersistentConn(long timeoutTs, SocketAddress addr, String host, SelectionKey key) {
         this.timeoutTs = timeoutTs;
         this.addr = addr;
         this.host = host;

--- a/src/java/org/httpkit/client/Request.java
+++ b/src/java/org/httpkit/client/Request.java
@@ -3,13 +3,13 @@ package org.httpkit.client;
 import org.httpkit.PriorityQueue;
 
 import javax.net.ssl.SSLException;
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 
 public class Request implements Comparable<Request> {
 
-    final InetSocketAddress addr;
+    final SocketAddress addr;
     final String host;
     final Decoder decoder;
     final ByteBuffer[] request; // HTTP request
@@ -25,7 +25,7 @@ public class Request implements Comparable<Request> {
 
     private long timeoutTs; // future time this request timeout, ms
 
-    public Request(InetSocketAddress addr, String host, ByteBuffer[] request, IRespListener handler,
+    public Request(SocketAddress addr, String host, ByteBuffer[] request, IRespListener handler,
                    PriorityQueue<Request> clients, RequestConfig config) {
         this.cfg = config;
         this.decoder = new Decoder(handler, config.method);
@@ -106,4 +106,3 @@ public class Request implements Comparable<Request> {
         clients.remove(this); // setConnected adds to timeouts queue, but we shouldn't time this out anymore
     }
 }
-

--- a/src/java/org/httpkit/server/HttpRequest.java
+++ b/src/java/org/httpkit/server/HttpRequest.java
@@ -3,6 +3,7 @@ package org.httpkit.server;
 import org.httpkit.*;
 
 import java.io.InputStream;
+import java.net.SocketAddress;
 import java.net.InetSocketAddress;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ public class HttpRequest {
     long startTime;
     boolean sentContinue = false;
 
-    InetSocketAddress remoteAddr;
+    SocketAddress remoteAddr;
     AsyncChannel channel;
 
     public HttpRequest(HttpMethod method, String url, HttpVersion version) {
@@ -67,7 +68,12 @@ public class HttpRequest {
                 return h.substring(0, idx);
             }
         } else {
-            return remoteAddr.getAddress().getHostAddress();
+            if (remoteAddr instanceof InetSocketAddress){
+                return ((InetSocketAddress)remoteAddr).getAddress().getHostAddress();
+            }else {
+                return null;
+            }
+
         }
     }
 

--- a/test/java/org/httpkit/SpecialHttpClient.java
+++ b/test/java/org/httpkit/SpecialHttpClient.java
@@ -20,7 +20,7 @@ public class SpecialHttpClient {
     // request + request sent to server, wait for 2 server responses
     public static String get2(String url) throws URISyntaxException, IOException {
         URI uri = new URI(url);
-        InetSocketAddress addr = HttpUtils.getServerAddr(uri);
+        SocketAddress addr = HttpUtils.getServerAddr(uri);
 
         Socket s = new Socket();
         s.connect(addr);
@@ -42,7 +42,7 @@ public class SpecialHttpClient {
 
     public static String http10(String url) throws Exception {
         URI uri = new URI(url);
-        InetSocketAddress addr = HttpUtils.getServerAddr(uri);
+        SocketAddress addr = HttpUtils.getServerAddr(uri);
 
         Socket s = new Socket();
         s.connect(addr);
@@ -66,7 +66,7 @@ public class SpecialHttpClient {
             IOException, InterruptedException {
 
         URI uri = new URI(url);
-        InetSocketAddress addr = HttpUtils.getServerAddr(uri);
+        SocketAddress addr = HttpUtils.getServerAddr(uri);
         Socket s = new Socket();
         s.setTcpNoDelay(false);
         s.connect(addr);
@@ -138,7 +138,7 @@ public class SpecialHttpClient {
     public static boolean slowWebSocketClient(String url) {
         try {
             URI uri = new URI(url);
-            InetSocketAddress addr = HttpUtils.getServerAddr(uri);
+            SocketAddress addr = HttpUtils.getServerAddr(uri);
 
             Socket s = new Socket();
             s.connect(addr);
@@ -204,7 +204,7 @@ public class SpecialHttpClient {
     public static String getPartial(String url) {
         try {
             URI uri = new URI(url);
-            InetSocketAddress addr = HttpUtils.getServerAddr(uri);
+            SocketAddress addr = HttpUtils.getServerAddr(uri);
 
             Socket s = new Socket();
             s.connect(addr);


### PR DESCRIPTION
In support of #461 

* Java/Clojure API's remain unchanged (purely additive)
* listen/bind address and channel providers are customizable in client and server (following current pattern)
* Added an example of using Unix Domain Sockets with JDK17+ to docs