### PR TITLE
[new] [Build] [#509] Add native-image test to CI (@borkdude)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build and Test
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -42,4 +42,4 @@ jobs:
           restore-keys: cljdeps-
 
       - name: Test native
-        run: bb native:test
+        run: bb test:native

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,5 +1,5 @@
 name: test native
-on: [push]
+on: [push, pull_request]
 defaults:
   run:
     working-directory: test-native

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,0 +1,45 @@
+name: test native
+on: [push]
+defaults:
+  run:
+    working-directory: test-native
+jobs:
+  test-native:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          version: 'latest'
+          java-version: '17'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@10.2
+        with:
+          # Install just one or all simultaneously
+          # The value must indicate a particular version of the tool, or use 'latest'
+          # to always provision the latest version
+          lein: 2.9.1                  # Leiningen
+          bb: latest
+
+      # Optional step:
+      - name: Cache clojure dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          # List all files containing dependencies:
+          key: cljdeps-${{ hashFiles('deps.edn') }}
+          # key: cljdeps-${{ hashFiles('deps.edn', 'bb.edn') }}
+          # key: cljdeps-${{ hashFiles('project.clj') }}
+          # key: cljdeps-${{ hashFiles('build.boot') }}
+          restore-keys: cljdeps-
+
+      - name: Test native
+        run: bb native:test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.iml
-.clj-kondo/
-.lsp/
+.cache
 .calva/
 *jar
 .classpath
@@ -15,3 +14,7 @@ pom.xml*
 /target
 /.idea
 /_site
+native-test-0.0.1-standalone
+native-test-0.0.1-standalone.build_artifacts.txt
+target
+.lein-repl-history

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,7 @@
+(ns build
+  (:require [babashka.process :refer [shell]]))
+
+(set! *warn-on-reflection* true)
+
+(defn lein-javac [_]
+  (shell "lein javac"))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,10 @@
+;; This deps.edn allows you to use httpkit as a deps.edn dependency
+;; When target/classes doesn't exist, you will be asked to run:
+;; clj -X:deps prep
+;; which calls `lein javac` to compile the java sources.
+{:paths ["src" "resources" "target/classes"]
+ :aliases {:build {:paths ["."]
+                   :deps {babashka/process {:mvn/version "0.4.16"}}}}
+ :deps/prep-lib {:alias :build
+                 :fn build/lein-javac
+                 :ensure "target/classes"}}

--- a/test-native/bb.edn
+++ b/test-native/bb.edn
@@ -3,7 +3,7 @@
              [clojure.string :as str])
   :init (do
           (def jar "target/native-test-0.0.1-standalone.jar")
-          (def native (if (fs/windows?)
+          (def binary (if (fs/windows?)
                         "native-test-0.0.1-standalone.exe"
                         "./native-test-0.0.1-standalone")))
   clean {:doc "Clean"
@@ -22,11 +22,11 @@
                 (clojure "-T:build uber"))}
   native {:doc "Compile native image"
           :depends [test:reflection uber]
-          :task (when (seq (fs/modified-since native jar))
+          :task (when (seq (fs/modified-since binary jar))
                   (shell "native-image"
                          "--initialize-at-build-time=clojure,org.httpkit,native"
                          "--no-fallback"
                                "-jar" jar))}
   test:native {:doc "Run native test"
                :depends [native]
-               :task (shell native)}}}
+               :task (shell binary)}}}

--- a/test-native/bb.edn
+++ b/test-native/bb.edn
@@ -1,0 +1,24 @@
+{:tasks
+ {:requires ([babashka.fs :as fs])
+  :init (do
+          (def jar "target/native-test-0.0.1-standalone.jar")
+          (def native (if (fs/windows?)
+                        "native-test-0.0.1-standalone.exe"
+                        "./native-test-0.0.1-standalone")))
+  prep {:doc "Prepares httpkit for usage in clj"
+        :task (when-not (fs/exists? "../../target/classes")
+                (clojure "-X:deps prep"))}
+  uber {:doc "Makes uberjar"
+        :depends [prep]
+        :task (when (seq (fs/modified-since jar ["src"]))
+                (clojure "-T:build uber"))}
+  native:build {:doc "Compile native image"
+                :depends [uber]
+                :task (when (seq (fs/modified-since native jar))
+                        (shell "native-image"
+                               "--initialize-at-build-time=clojure,org.httpkit,native"
+                               "--no-fallback"
+                               "-jar" jar))}
+  native:test {:doc "Run native test"
+               :depends [native:build]
+               :task (shell native)}}}

--- a/test-native/bb.edn
+++ b/test-native/bb.edn
@@ -1,24 +1,32 @@
 {:tasks
- {:requires ([babashka.fs :as fs])
+ {:requires ([babashka.fs :as fs]
+             [clojure.string :as str])
   :init (do
           (def jar "target/native-test-0.0.1-standalone.jar")
           (def native (if (fs/windows?)
                         "native-test-0.0.1-standalone.exe"
                         "./native-test-0.0.1-standalone")))
+  clean {:doc "Clean"
+         :task (do (fs/delete-tree "target")
+                   (fs/delete-tree "../target"))}
   prep {:doc "Prepares httpkit for usage in clj"
         :task (when-not (fs/exists? "../../target/classes")
                 (clojure "-X:deps prep"))}
+  test:reflection {:doc "Test reflection issues"
+                   :depends [prep]
+                   :task (let [err (:err (clojure {:err :string} "-M:dev -m native.test"))]
+                           (assert (not (str/includes? err "Reflection warning"))))}
   uber {:doc "Makes uberjar"
         :depends [prep]
         :task (when (seq (fs/modified-since jar ["src"]))
                 (clojure "-T:build uber"))}
-  native:build {:doc "Compile native image"
-                :depends [uber]
-                :task (when (seq (fs/modified-since native jar))
-                        (shell "native-image"
-                               "--initialize-at-build-time=clojure,org.httpkit,native"
-                               "--no-fallback"
+  native {:doc "Compile native image"
+          :depends [test:reflection uber]
+          :task (when (seq (fs/modified-since native jar))
+                  (shell "native-image"
+                         "--initialize-at-build-time=clojure,org.httpkit,native"
+                         "--no-fallback"
                                "-jar" jar))}
-  native:test {:doc "Run native test"
-               :depends [native:build]
+  test:native {:doc "Run native test"
+               :depends [native]
                :task (shell native)}}}

--- a/test-native/build.clj
+++ b/test-native/build.clj
@@ -1,0 +1,33 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [clojure.edn :as edn]))
+
+(def project (-> (edn/read-string (slurp "deps.edn"))
+                 :aliases :neil :project))
+(def lib (or (:name project) 'my/native-test))
+
+;; use neil project set version 1.2.0 to update the version in deps.edn
+
+(def version (or (:version project)
+                 "0.0.1"))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn uber [_]
+  (clean nil)
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/compile-clj {:basis basis
+                  :src-dirs ["src"]
+                  :class-dir class-dir})
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :basis basis
+           :main 'native.test})
+  (println "Created uberjar:" uber-file))
+
+

--- a/test-native/build.clj
+++ b/test-native/build.clj
@@ -1,15 +1,9 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]
-            [clojure.edn :as edn]))
+  (:require [clojure.tools.build.api :as b]))
 
-(def project (-> (edn/read-string (slurp "deps.edn"))
-                 :aliases :neil :project))
-(def lib (or (:name project) 'my/native-test))
+(def lib 'my/native-test)
 
-;; use neil project set version 1.2.0 to update the version in deps.edn
-
-(def version (or (:version project)
-                 "0.0.1"))
+(def version "0.0.1")
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
@@ -29,5 +23,3 @@
            :basis basis
            :main 'native.test})
   (println "Created uberjar:" uber-file))
-
-

--- a/test-native/deps.edn
+++ b/test-native/deps.edn
@@ -1,6 +1,7 @@
 {:deps {httpkit/httpkit {:local/root ".."}}
  :aliases
- {:build ;; added by neil
+ {:dev {:extra-paths ["dev"]}
+  :build ;; added by neil
   {:deps {io.github.clojure/tools.build {:git/tag "v0.9.3" :git/sha "e537cd1"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}
    :ns-default build}}}

--- a/test-native/deps.edn
+++ b/test-native/deps.edn
@@ -1,0 +1,6 @@
+{:deps {httpkit/httpkit {:local/root ".."}}
+ :aliases
+ {:build ;; added by neil
+  {:deps {io.github.clojure/tools.build {:git/tag "v0.9.3" :git/sha "e537cd1"}
+          slipset/deps-deploy {:mvn/version "0.2.0"}}
+   :ns-default build}}}

--- a/test-native/dev/user.clj
+++ b/test-native/dev/user.clj
@@ -1,0 +1,3 @@
+(ns user)
+
+(alter-var-root #'*warn-on-reflection* (constantly true))

--- a/test-native/src/native/test.clj
+++ b/test-native/src/native/test.clj
@@ -1,0 +1,24 @@
+(ns native.test
+  (:require [org.httpkit.client :as client]
+            [org.httpkit.server :as server]
+            [org.httpkit.sni-client :as sni-client]
+            [clojure.test :as t])
+  (:gen-class))
+
+(defn -main [& _args]
+  (let [!server (atom nil)]
+    (try (let [server (server/run-server (fn [_]
+                                           {:body "response"
+                                            :status 200
+                                            :headers {"content-type" "text/plain"}})
+                                         {:port 12233
+                                          :legacy-return-value? false})]
+           (reset! !server server)
+           (t/is (= "response" (:body @(client/get "http://localhost:12233"))))
+           (t/is (= "response" (:body @(client/get "http://localhost:12233" {:client @sni-client/default-client}))))
+           (println "Native test succesful!"))
+         (catch Exception e
+           (println e) (System/exit 1))
+         (finally
+           (server/server-stop! @!server)
+           (shutdown-agents)))))


### PR DESCRIPTION
This commit adds:

* a test-native project in which httpkit client + server is tests with GraalVM native-image
* a deps.edn which is used by test-native but can be used by any deps.edn user
* a Github Action yml for running test-native in linux, macOS and Windows
* reflection fixes in httpkit server which were found during the tests

Fixes #509 