### PR TITLE
Reliably close InputStream

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -1,7 +1,7 @@
-name: Build and Test
+name: Main tests
 on: [push, pull_request]
 jobs:
-  build-and-test:
+  tests:
     runs-on: ubuntu-latest
     container: clojure:openjdk-17-lein-buster
     steps:

--- a/.github/workflows/tests-native.yml
+++ b/.github/workflows/tests-native.yml
@@ -1,4 +1,4 @@
-name: test native
+name: Native tests
 on: [push, pull_request]
 defaults:
   run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 > This project uses [Break Versioning](https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md)
 
-## `v2.7.0-RC1` (2023 May 30)
+## `2.7.0-RC1` (2023 May 30)
 
 📦 `2.7.0-RC1` on [Clojars](https://clojars.org/http-kit/versions/2.7.0-RC1)
 
 Identical to `2.7.0-beta3`.
 
 
-## `v2.7.0-beta3` (2023 May 3)
+## `2.7.0-beta3` (2023 May 3)
 
 📦 `2.7.0-beta3` on [Clojars](https://clojars.org/http-kit/versions/2.7.0-beta3)
 
@@ -16,7 +16,7 @@ Identical to `2.7.0-beta2` except for:
 * 10501a5 [fix] [#520] Remove unintended dependency on `cider-nrepl` plugin (@harold)
 
 
-## `v2.7.0-beta2` (2023 Apr 24)
+## `2.7.0-beta2` (2023 Apr 24)
 
 📦 `2.7.0-beta2` on [Clojars](https://clojars.org/http-kit/versions/2.7.0-beta2)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # http-kit
 
-### Simple, high-performance event-driven HTTP client+server for Clojure
+## Simple, high-performance event-driven HTTP client+server for Clojure
 
 ### Latest releases
 
 - 2023-05-30: `2.7.0-RC1` (dev): [release notes](https://github.com/http-kit/http-kit/releases/tag/v2.7.0-RC1) | [Clojars](https://clojars.org/http-kit/versions/2.7.0-RC1)
 - 2022-06-13: `2.6.0`  (stable): [release notes](https://github.com/http-kit/http-kit/releases/tag/v2.6.0) | [Clojars](https://clojars.org/http-kit/versions/2.6.0)
 
-![github actions](https://github.com/http-kit/http-kit/actions/workflows/build.yml/badge.svg)
+[![Main tests](https://github.com/http-kit/http-kit/actions/workflows/tests-main.yml/badge.svg)](https://github.com/http-kit/http-kit/actions/workflows/tests-main.yml) [![Native tests](https://github.com/http-kit/http-kit/actions/workflows/tests-native.yml/badge.svg)](https://github.com/http-kit/http-kit/actions/workflows/tests-native.yml)
 
 ### Resources
-1. [Wiki][wiki] - **community docs** (new!) 👈
+1. [Wiki][wiki] - **community docs** (👈 start here)
 1. [Release info][] - releases and changes
 1. [API docs][] - auto-generated API docs
-1. [GitHub issues][] - for support requests and [contributions][]
+1. [GitHub issues][] - for support requests, contributions, etc.
 
 ### Status
 
@@ -21,12 +21,11 @@ http-kit was created by [@shenfeng][], but is currently being maintained by its 
 
 A big thank-you to the [current contributors](https://github.com/http-kit/http-kit/graphs/contributors) for keeping the project going! **Additional contributors very welcome**: please ping me if you'd be interested in lending a hand.
 
-\- [Peter Taoussanis][@ptaoussanis]
-
+\- [Peter Taoussanis][]
 
 ### Features
 
-> Links below point to the [legacy website][], which is currently unmaintained and may be outdated. A community effort is [now underway][wiki] to slowly transition away from the legacy website.
+> Links below point to the [legacy website](https://http-kit.github.io), which is currently unmaintained and may be outdated. A community effort is [now underway][wiki] to slowly transition away from the legacy website.
 
 - **Ring compliant**: http-kit is an [(almost)](http://http-kit.github.io/migration.html) drop-in replacement for the standard Ring Jetty adapter. So you can use it with all your current libraries (e.g. [Compojure](http://http-kit.github.io/server.html#routing)) and middleware.
 
@@ -40,15 +39,17 @@ A big thank-you to the [current contributors](https://github.com/http-kit/http-k
 
 - **WebSockets and Comet**: With great out-the-box support for both [WebSockets](http://http-kit.github.io/server.html#websocket) and efficient handling of [long-held HTTP requests](http://http-kit.github.io/server.html#async), realtime web applications are a breeze to write.
 
----
+## License
 
-Copyright &copy; 2012-2023 [@shenfeng][] and contributors. Distributed under the [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
+Copyright &copy; 2012-2023 [@shenfeng][] and contributors, licensed under [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html).
 
+<!--- Common links -->
 [wiki]: ../../wiki
 [Release info]: ../../releases
-[API docs]: http://http-kit.github.io/http-kit/
 [GitHub issues]: ../../issues
-[contributions]: ../../blob/master/CONTRIBUTING.md
+[Peter Taoussanis]: https://www.taoensso.com
+
+<!--- Repo links -->
+[API docs]: http://http-kit.github.io/http-kit/
 [@shenfeng]: https://github.com/shenfeng
-[@ptaoussanis]: https://github.com/ptaoussanis
-[legacy website]: https://http-kit.github.io
+

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -312,14 +312,17 @@ public class HttpUtils {
     }
 
     public static DynamicBytes readAll(InputStream is) throws IOException {
-        DynamicBytes bytes = new DynamicBytes(32768); // init 32k
-        byte[] buffer = new byte[16384];
-        int read;
-        while ((read = is.read(buffer)) != -1) {
-            bytes.append(buffer, read);
+        try {
+            DynamicBytes bytes = new DynamicBytes(32768); // init 32k
+            byte[] buffer = new byte[16384];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                bytes.append(buffer, read);
+            }
+            return bytes;
+        } finally {
+            is.close();
         }
-        is.close();
-        return bytes;
     }
 
     public static String getStringValue(Map<String, Object> headers, String key) {


### PR DESCRIPTION
The `readAll` function reads all data from a stream. If the size of the data is too large, JVM will throw `OutOfMemoryError`. In this case `is.close()` will not be called which could lead to resource leak.