### PR TITLE
[fix] [client] fix handling of some bad ssl certificates

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -89,9 +89,7 @@ public class HttpClient implements Runnable {
     public static SSLContext getDefaultContext() {
         if(defaultContext==null) {
             try {
-                SSLContext sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(null, TrustManagerFactory.getTrustManagers() ,null);
-                defaultContext = sslContext;
+                defaultContext = SSLContext.getDefault();
             } catch (Exception e) {
                 throw new Error("Failed to initialize SSLContext", e);
             }


### PR DESCRIPTION
Broke in e28e4c6e77835d2768a117f12a4ab3e3a42283b2 (between v2.3.0 and v2.4.0-alpha1)