### PR TITLE
[new] [server] [#394] Add support for Ring async handler arities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,11 @@ This will build the java source and test files, it will then execute 'lein test'
 
 To run the java junit tests, at the root of the project type:
 
-```rake junit```
+```rake test_java```
 
 To run a set of benchmarks, at the root of the project type:
 
-```rake benchmark```
-
+```rake bench```
 
 ## Filing Pull Requests
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,40 +1,16 @@
 task :default => :test
 
-desc "Run unit test"
+desc "Run Clojure unit tests"
 task :test do
   sh './scripts/javac with-test && lein test'
 end
 
-desc "Run java unit tests"
-task :junit do
+desc "Run Java unit tests"
+task :test_java do
   sh './scripts/junit'
 end
 
-desc "Run some benchmark test"
-task :benchmark do
+desc "Run ^:benchmark tests"
+task :bench do
   sh './scripts/javac with-test && lein test :benchmark'
 end
-
-desc "Install in local repository"
-task :install_local => :test do
-  sh 'lein deps && rm -rf *.jar pom.xml classes target && lein jar && lein install'
-  sh 'cd ~/workspace/rssminer && lein deps'
-end
-
-desc "Install in clojars repository"
-task :clojars => :test do
-  sh 'rm -rf *.jar pom.xml classes target && lein pom && lein jar'
-  sh "cp target/provided/*.jar ."
-  sh 'scp pom.xml *.jar clojars@clojars.org:'
-end
-
-desc "Start swank server for emacs"
-task :swank do
-  sh "./scripts/javac with-test && lein swank"
-end
-
-# desc "Benchmark to an idea how fast it can run"
-# task :bench do
-#   sh 'rm -rf classes/ && lein deps && lein javac'
-#   sh './scripts/benchmark bench'
-# end

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,8 @@
   {:name "Apache License, Version 2.0"
    :url  "https://www.apache.org/licenses/LICENSE-2.0.html"}
 
+  :global-vars {*warn-on-reflection* true}
+
   :dependencies []
 
   :javac-options     ["--release" "8" "-g"] ; Oldest version JVM to support
@@ -15,10 +17,10 @@
 
   :test-paths ["test"]
   :test-selectors
-  {:default (complement :benchmark)
-   :gha  (complement #(or (:benchmark %) (:skip-gha %)))
-   :benchmark :benchmark
-   :all (fn [_] true)}
+  {:all     (constantly true)
+   :default (complement :benchmark)
+   :gha     (complement #(or (:benchmark %) (:skip-gha %)))
+   :benchmark :benchmark}
 
   :profiles
   {;; :default [:base :system :user :provided :dev]
@@ -29,11 +31,7 @@
 
    :test
    {:java-source-paths ["test/java" "src/java"]
-    :jvm-opts
-    ["-Xms1024m" "-Xmx2048m" ; Testing https require more memory
-     "-Dclojure.compiler.disable-locals-clearing=true"]
-
-    :global-vars {*warn-on-reflection* true}
+    :jvm-opts ["-server" "-Xms1024m" "-Xmx2048m"]
     :dependencies
     [[ring/ring-defaults        "0.4.0"]
      [ring-request-proxy        "0.1.11"]
@@ -43,29 +41,27 @@
    :dev
    [:c1.11 :test
     {:resource-paths ["test/resources"]
-     :jvm-opts ["-server"]
      :dependencies
-     [[org.clojure/clojure             "1.8.0"] ; TODO Update (blocked on `http.async.client` update`)
+     [[org.clojure/clojure            "1.11.1"]
       [junit/junit                    "4.13.2"]
       [org.clojure/tools.logging       "1.2.4"]
       [ch.qos.logback/logback-classic "1.4.11"]
       [clj-http                       "3.12.3"]
-      [io.netty/netty-all       "4.1.52.Final"]
+      [io.netty/netty-all       "4.1.98.Final"]
       [org.clojure/data.json           "2.4.0"]
-      [http.async.client               "1.2.0"] ; TODO Update (breaking)
+      [http.async.client               "1.3.0"] ; Newer versions fail
       [compojure                       "1.7.0"]
       [org.clojure/tools.cli         "1.0.219"]
-      [ring/ring-jetty-adapter         "1.5.1"] ; TODO Update (breaking)
+      [ring/ring-jetty-adapter         "1.5.1"] ; Newer versions fail
       [ring/ring-core                 "1.10.0"]]
 
      :plugins
-     [[lein-swank   "1.4.5"]
-      [lein-pprint  "1.3.2"]
+     [[lein-pprint  "1.3.2"]
       [lein-ancient "0.7.0"]
       [lein-codox   "0.10.8"]]}]
 
    :nrepl
    {:dependencies [[nrepl "1.0.0"]]
     :plugins
-    [[cider/cider-nrepl         "0.30.0"]
-     [mx.cider/enrich-classpath "1.17.2"]]}})
+    [[cider/cider-nrepl         "0.38.1"]
+     [mx.cider/enrich-classpath "1.18.0"]]}})

--- a/scripts/javac
+++ b/scripts/javac
@@ -3,10 +3,10 @@
 rm -rf target && mkdir -p target/classes
 
 CP=`lein classpath`
-find src/java -name "*.java" | xargs javac -Xlint:unchecked -g -target 1.7 -source 1.7 -encoding utf8 -cp $CP -d target/classes -sourcepath src/java/
+find src/java -name "*.java" | xargs javac -cp $CP -d target/classes -sourcepath src/java/
 
 if [ $# -gt 0 ]; then
     # lein test need it
     echo "compile java test code"
-    find test/java -name "*.java" | xargs javac -g -Xlint:unchecked -target 1.7 -source 1.7 -encoding utf8 -cp $CP -d target/classes -sourcepath test/java
+    find test/java -name "*.java" | xargs javac -cp $CP -d target/classes -sourcepath test/java
 fi

--- a/scripts/junit
+++ b/scripts/junit
@@ -5,10 +5,10 @@ rm -rf target && mkdir -p target/classes
 CP=`lein classpath`
 
 echo "compile java code"
-find src/java -name "*.java" | xargs javac -Xlint:unchecked -g -target 1.6 -source 1.6 -encoding utf8 -cp $CP -d target/classes -sourcepath src/java/
+find src/java -name "*.java" | xargs javac -cp $CP -d target/classes -sourcepath src/java/
 
 echo "compile java test code"
-find test/java -name "*.java" | xargs javac -g -Xlint:unchecked -target 1.6 -source 1.6 -encoding utf8 -cp $CP -d target/classes -sourcepath test/java
+find test/java -name "*.java" | xargs javac -cp $CP -d target/classes -sourcepath test/java
 
 # add resources
 java -cp $CP org.junit.runner.JUnitCore org.httpkit.HttpKitTestSuite

--- a/scripts/run_http_requests
+++ b/scripts/run_http_requests
@@ -5,7 +5,7 @@ mkdir target
 
 CP="classes:$(lein classpath)"
 
-# find src/java -name "*.java" | xargs javac -g -Xlint:unchecked -encoding utf8 -cp "$CP" -d classes -sourcepath src/java/
+# find src/java -name "*.java" | xargs javac -g -cp "$CP" -d classes -sourcepath src/java/
 
 # lein javac
 

--- a/scripts/start_raw_io_server
+++ b/scripts/start_raw_io_server
@@ -1,6 +1,6 @@
 #! /bin/bash -x
 
-# simplest NIO server to have a sense of how fast It can be
+# simplest NIO server to have a sense of how fast it can be
 
 cd test/java/
 
@@ -11,10 +11,9 @@ else
 
 fi
 
-
 exit
 
-# benchamark
+# benchmark
 # wrk -t2 -c200 -d4 http://192.168.1.101:8000/ && sleep 1 && wrk -t2 -c200 -d10 http://192.168.1.101:8000/
 
 # Fri Apr 12 14:56:27 CST 2013
@@ -41,6 +40,6 @@ exit
 
 # 15k
 
-# bulck => 130214.72
+# bulk => 130214.72
 # non-direct => 120193.54
 # direct => 137388.65

--- a/scripts/start_sslbench_server
+++ b/scripts/start_sslbench_server
@@ -5,7 +5,7 @@
 CP=`lein classpath`
 
 java -cp "$CP" \
-    -Xms256m -Xmx256m \
+    -Xms1024m -Xmx1024m \
     -Xdebug -Xrunjdwp:transport=dt_socket,address=9094,server=y,suspend=n \
     -XX:HeapDumpPath=/tmp -XX:+HeapDumpOnOutOfMemoryError \
     clojure.main -m org.httpkit.ssl-bench

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -112,7 +112,7 @@
               proxy-protocol worker-pool
               error-logger warn-logger event-logger event-names
               legacy-return-value? server-header address-finder
-              channel-factory] :as opts
+              channel-factory ring-async?] :as opts
 
        :or   {ip         "0.0.0.0"
               port       8090
@@ -121,7 +121,8 @@
               max-line   8192
               proxy-protocol :disable
               legacy-return-value? true
-              server-header "http-kit"}}]]
+              server-header "http-kit"
+              ring-async? false}}]]
 
   (let [^ContextLogger err-logger
         (if error-logger
@@ -152,7 +153,7 @@
         worker-pool (or (force worker-pool) (:pool (new-worker (get opts :pool-opts opts))))
 
         ^org.httpkit.server.IHandler h
-        (RingHandler. handler worker-pool
+        (RingHandler. handler ring-async? worker-pool
           err-logger evt-logger evt-names server-header)
 
         ^ProxyProtocolOption proxy-enum

--- a/test/java/org/httpkit/server/RingHandlerTest.java
+++ b/test/java/org/httpkit/server/RingHandlerTest.java
@@ -30,7 +30,7 @@ public class RingHandlerTest {
         Vector<String> assertionItems = new Vector<String>();
 
         ExecutorService testWorkerPool = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, new ArrayBlockingQueue<Runnable>(2));
-        RingHandler ringHandler = new RingHandler(new MockClojureHandler(aDummyResponse()), testWorkerPool);
+        RingHandler ringHandler = new RingHandler(new MockClojureHandler(aDummyResponse()), false, testWorkerPool);
         ringHandler.handle(aDummyRequest(), new MockRespCallback(assertionItems));
 
         Thread.sleep(50);
@@ -42,7 +42,7 @@ public class RingHandlerTest {
     public void shouldUseInternalThreadPoolForExecution() throws InterruptedException, ProtocolException, LineTooLargeException, RequestTooLargeException {
         Vector<String> assertionItems = new Vector<String>();
 
-        RingHandler ringHandler = new RingHandler(1, new MockClojureHandler(aDummyResponse()), "some-prefix", 2, "http-kit");
+        RingHandler ringHandler = new RingHandler(1, new MockClojureHandler(aDummyResponse()), false, "some-prefix", 2, "http-kit");
         ringHandler.handle(aDummyRequest(), new MockRespCallback(assertionItems));
 
         Thread.sleep(50);

--- a/test/org/httpkit/benchmark.clj
+++ b/test/org/httpkit/benchmark.clj
@@ -1,22 +1,24 @@
 (ns org.httpkit.benchmark
-  (:use org.httpkit.server
-        org.httpkit.test-util
-        [clojure.tools.cli :only [cli]]))
+  (:require
+   [org.httpkit.server    :as hks]
+   [org.httpkit.test-util :as tu]
+   [clojure.tools.cli :refer [cli]]))
 
 (defn handler [req]
   {:status 200
-   :headers {"Content-Type" "text/plain"
-             "X-header" "美味书签"}
-   ;; jdk 6 is slow here, jdk7 is fine. String implemented differently
+   :headers {"Content-Type" "text/plain"}
    :body "hello world"})
 
-;;; extreme case.
-;;; more real world, see server_test.clj
-(defn -main [& args]
+(defn -main
+  "Start server for benching.
+  Tests with `^:benchmark` metadata will be run."
+  [& args]
+
   (let [[options _ banner]
         (cli args
-             ["-p" "--port" "Port to listen" :default 9090 :parse-fn to-int]
-             ["--[no-]help" "Print this help"])]
+          ["-p" "--port" "Port to listen" :default 9090 :parse-fn tu/to-int]
+          ["--[no-]help" "Print this help"])]
+
     (when (:help options) (println banner) (System/exit 0))
-    (run-server handler {:port (options :port)})
-    (println (str "listen on port :" (options :port)))))
+    (hks/run-server handler {:port   (options :port)})
+    (println (str "Listening on port :" (options :port)))))

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -218,36 +218,37 @@
           (is (= 200 (:status @r))))))))
 
 (deftest ^:benchmark performance-bench
+  (println "\nBenching clients...")
+
   (let [url "http://127.0.0.1:14347/get"]
-    ;; just for fun
-    (bench "http-kit, concurrency 1, 3000 requests: "
-      (doseq [_ (range 0 3000)] @(hkc/get url)))
-
-    (bench "clj-http, concurrency 1, 3000 requests: "
-      (doseq [_ (range 0 3000)] (clj-http/get url)))
-
-    (bench "http-kit, concurrency 10, 3000 requests: "
+    (println)
+    (println "Concurrency 1, 3k requests")
+    (bench "  http-kit: " (doseq [_ (range 0 3000)] @(hkc/get     url)))
+    (bench "  clj-http: " (doseq [_ (range 0 3000)] (clj-http/get url)))
+    (println)
+    (println "Concurrency 10, 3k requests")
+    (bench "  http-kit: "
       (doseq [_ (range 0 300)]
-        (let [requests (doall (map (fn [u] (hkc/get u))
-                                        (repeat 10 url)))]
-          (doseq [r requests] @r))))) ; wait all finish
+        (let [requests (doall (map (fn [u] (hkc/get u)) (repeat 10 url)))]
+          (doseq [r requests] @r)))))
 
   (let [url "https://127.0.0.1:9898/get"]
-    (bench "http-kit, https, concurrency 1, 1000 requests: "
-      (doseq [_ (range 0 1000)] @(hkc/get url {:insecure? true})))
-
-    (bench "http-kit, https, concurrency 10, 1000 requests: "
+    (println)
+    (println "Concurrency 1, 1k requests, https")
+    (bench "  http-kit: " (doseq [_ (range 0 1000)] @(hkc/get     url {:insecure? true})))
+    (bench "  clj-http: " (doseq [_ (range 0 1000)] (clj-http/get url {:insecure? true})))
+    (println)
+    (println "Concurrency 10, 1k requests, https")
+    (bench "  http-kit: "
       (doseq [_ (range 0 100)]
-        (let [requests (doall (map (fn [u] (hkc/get u {:insecure? true}))
-                                (repeat 10 url)))]
-          (doseq [r requests] @r)))) ; wait all finish
+        (let [requests (doall (map (fn [u] (hkc/get u {:insecure? true})) (repeat 10 url)))]
+          (doseq [r requests] @r))))
 
-    (bench "clj-http, https, concurrency 1, 1000 requests: "
-      (doseq [_ (range 0 1000)] (clj-http/get url {:insecure? true})))
-
-    (bench "http-kit, https, keepalive disabled, concurrency 1, 1000 requests: "
-      (doseq [_ (range 0 1000)] @(hkc/get url {:insecure? true
-                                               :keepalive -1})))))
+    (println)
+    (println "Concurrency 1, 1k requests, https, no keepalive")
+    (bench "  http-kit: " (doseq [_ (range 0 1000)] @(hkc/get url {:insecure? true :keepalive -1})))
+    (println)
+    (println "Finished benching clients")))
 
 (deftest test-http-client-user-agent
   (let [ua "test-ua"


### PR DESCRIPTION
This patch adds support for the three-arity async handlers introduced in Ring 1.6, and closes #394. The `:ring-async?` option, off by default, toggles support for async Ring handlers.