### PR TITLE
Fix broken links in getting started wiki.

### DIFF
--- a/wiki/1-Getting-started.md
+++ b/wiki/1-Getting-started.md
@@ -9,7 +9,7 @@ deps.edn:   http-kit/http-kit {:mvn/version "x-y-z"}
 
 # Usage
 
-See the [client](./2-Client) or [server](./3-Server) sections for more!
+See the [client](./2-Client.md) or [server](./3-Server.md) sections for more!
 
 # Tests and benchmarks
 
@@ -21,4 +21,4 @@ lein test        # Run the unit tests
 lein test :bench # Run the benchmark suite with default opts
 ```
 
-See the [benchmarking](./4-Benchmarking) section for lots more info on http-kit's **benchmark suite**.
+See the [benchmarking](./4-Benchmarking.md) section for lots more info on http-kit's **benchmark suite**.


### PR DESCRIPTION
![looping-page-not-found-gif-by-starface](https://github.com/http-kit/http-kit/assets/8226466/a2b1af27-e6c9-447e-b3c7-b5ea697926e7)


The links on this wiki page were broken; I tested to make sure and it was just missing the file extensions.