### PR TITLE
Fix order of  err-logger and warn-logger

### DIFF
--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -174,8 +174,8 @@
 
         s (HttpServer. address-finder channel-factory h
                        ^long max-body ^long max-line ^long max-ws proxy-enum ^String server-header
-                       warn-logger
                        err-logger
+                       warn-logger
                        evt-logger
                        evt-names)]
     (.start s)


### PR DESCRIPTION
The HttpServer constructor expects a different order of these.
Fixes #552.