### PR TITLE
Support for non-ASCII characters on multipart filename

### DIFF
--- a/src/java/org/httpkit/client/MultipartEntity.java
+++ b/src/java/org/httpkit/client/MultipartEntity.java
@@ -42,7 +42,7 @@ public class MultipartEntity {
                 bytes.append("Content-Disposition: form-data; name=\"");
                 bytes.append(e.name, HttpUtils.UTF_8);
                 if (e.filename != null) {
-                    bytes.append("\"; filename=\"").append(e.filename).append("\"\r\n");
+                    bytes.append("\"; filename=\"").append(e.filename, HttpUtils.UTF_8).append("\"\r\n");
                 } else {
                     bytes.append("\"\r\n");
                 }


### PR DESCRIPTION
- When executing a POST request to a mail broker, file attachments which include non-ascii characters on its filename get its non-ascii characters replaced by '?'. 
- We use lots of attachments with spanish characters on its filenames. Support for non-ascii characters like 'ñ' or 'á' would be ideal.
- The suggestion is to use UTF-8 encoding for filename instead of the default ISO-8859-1.