### PR TITLE
wiki/3-Server.md: add writeup for websockets (was -> "start writeup for WebSocket handling")

### DIFF
--- a/wiki/3-Server.md
+++ b/wiki/3-Server.md
@@ -106,7 +106,7 @@ On the surface, except for syntactical differences, these really look the same. 
 
 - with the unified API, you really only need to write one set of code (even right down to using the same `data` argument for `send!`) server-side if you want to support both WebSockets, and HTTP long-polling (perhaps as a fallback). Not so if you use the Ring WebSocket API. You will need to write separate code to handle HTTP long-polling.
 
-- with the unified API, detecting success or failure for `send!` (which is asynchronous already, by the way) is easy enough: just check the return value, no callbacks necessary. With the Ring WebSocket API, if you intend to send asynchronously, you will need to construct your own callback functions with each `send` (no data is otherwise provided to callbacks to link the success/failure back to the specific `send`).
+- with the unified API, detecting success or failure for `send!` (which is asynchronous already, by the way) is easy enough: just check the return value, no callbacks necessary. With the Ring WebSocket API, if you intend to send asynchronously, you will need to construct your own callback functions with each `send` (essentially closures; no data is otherwise provided to callbacks to link the success/failure back to the specific `send`).
 
 - with the unified API, you do not get the `reason` for a WebSocket close. The Ring WebSocket API, on the other hand, does provide a `reason` parameter. In practice, though (at least for a proper close), the reason is often empty (as of Jun 3 2024), and all you need is the status code, which both APIs provide.
 

--- a/wiki/3-Server.md
+++ b/wiki/3-Server.md
@@ -46,7 +46,7 @@ There are 2 ways to handle WebSockets with `http-kit`:
 ### Approach 1
 
 ```clj
-(ns demo
+(ns example.unified-api
   (:require [org.httpkit.server :as hk-server]))
 
 (def channels (atom #{}))

--- a/wiki/3-Server.md
+++ b/wiki/3-Server.md
@@ -40,10 +40,10 @@ The `run-server` call above returns a stop function that you can call like so:
 ## Websockets
 
 There are 2 ways to handle WebSockets with `http-kit`:
-- use `http-kit`'s own unified API for WebSocket and HTTP long-polling/streaming
-- use the Ring's experimental (see https://github.com/ring-clojure/ring/wiki/WebSockets) WebSocket API
+1. use `http-kit`'s own unified API for WebSocket and HTTP long-polling
+1. use the Ring's experimental (see https://github.com/ring-clojure/ring/wiki/WebSockets) WebSocket API
 
-### Approach 1
+#### example code using the unified API
 
 ```clj
 (ns example.unified-api
@@ -72,7 +72,7 @@ There are 2 ways to handle WebSockets with `http-kit`:
 (def server (hk-server/run-server app {:port 8080}))
 ```
 
-### Approach 2
+#### example code using Ring's WebSocket API
 
 ```clj
 (ns example.ring-api
@@ -101,6 +101,14 @@ There are 2 ways to handle WebSockets with `http-kit`:
 
 (def server (hk-server/run-server app {:port 8080}))
 ```
+
+On the surface, except for syntactical differences, these really look the same. But let's dive deeper:
+
+- with the unified API, you really only need to write one set of code (even right down to using the same `data` argument for `send!`) server-side if you want to support both WebSockets, and HTTP long-polling (perhaps as a fallback). Not so if you use the Ring WebSocket API. You will need to write separate code to handle HTTP long-polling.
+
+- with the unified API, detecting success or failure for `send!` (which is asynchronous already, by the way) is easy enough: just check the return value, no callbacks necessary. With the Ring WebSocket API, if you intend to send asynchronously, you will need to construct your own callback functions with each `send` (no data is otherwise provided to callbacks to link the success/failure back to the specific `send`).
+
+- with the unified API, you do not get the `reason` for a WebSocket close. The Ring WebSocket API, on the other hand, does provide a `reason` parameter. In practice, though (at least for a proper close), the reason is often empty (as of Jun 3 2024), and all you need is the status code, which both APIs provide.
 
 ## Production environments
 

--- a/wiki/3-Server.md
+++ b/wiki/3-Server.md
@@ -41,7 +41,7 @@ The `run-server` call above returns a stop function that you can call like so:
 
 There are 2 ways to handle WebSockets with `http-kit`:
 - use `http-kit`'s own unified API for WebSocket and HTTP long-polling/streaming
-- use the standard Ring WebSocket API
+- use the Ring's experimental (see https://github.com/ring-clojure/ring/wiki/WebSockets) WebSocket API
 
 ### Approach 1
 


### PR DESCRIPTION
as promised in https://github.com/http-kit/http-kit/issues/570#issuecomment-2143496684

I wasn't too sure about the exact placement or structure, but figured I could just start, and you can then edit or shift as necessary. In that vein, I have only the barest of intros for the 2 approaches, and the main body of my work is in the demo code instead.