### PR TITLE
check if content-encoding `deflate` carries zip envelope when setting up Inflater

### DIFF
--- a/test/java/org/httpkit/client/TextClientTest.java
+++ b/test/java/org/httpkit/client/TextClientTest.java
@@ -32,7 +32,8 @@ public class TextClientTest {
         String[] urls = new String[]{"http://feed.feedsky.com/amaze",
                 "http://macorz.cn/feed", "http://www.ourlinux.net/feed",
                 "http://blog.jjgod.org/feed/", "http://www.lostleon.com/blog/feed/",
-                "http://feed.feedsky.com/hellodb"};
+                "http://feed.feedsky.com/hellodb", "https://httpbin.org/deflate"
+	};
 
         runIt(urls);
 


### PR DESCRIPTION
fixes http-kit/http-kit#574

This fix was cribbed from https://github.com/apache/httpcomponents-client/blob/master/httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateInputStream.java