### PR TITLE
Fix #578

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -214,8 +214,20 @@ public class HttpServer implements Runnable {
                     // AsyncChannel channel = atta.channel;
                     //
                     // Ref. #375, thanks to @osbert for identifying this risk!
-
-                    AsyncChannel channel = new AsyncChannel(key, this); // This okay?
+                    //
+                    // The change from #375 was preventing the close handler from firing.
+                    // This was due to creating new AsyncChannel which did not have a
+                    // close handler set.
+                    //
+                    // To fix this we only create a new channel if the previous one was
+                    // closed. This prevents the issue of closed channels being reopened 
+                    // and reused described above. But, still ensures the close handler 
+                    // for a channel is called correctly.                    
+                    // AsyncChannel channel new AsyncChannel(key, this);
+                    //
+                    // Ref. #578
+                    //
+                    AsyncChannel channel = atta.channel.isClosed() ? new AsyncChannel(key, this) : atta.channel;
 
                     if (status.get() != Status.RUNNING) {
                         request.isKeepAlive = false;

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -537,29 +537,29 @@
   (http/with-async-connection-pool {:threads 1}
     (let [ch_          (atom nil)
           fired-close_ (atom nil)
-          captured_ (atom []) ; [<send-success?> ...]
-          capture!  (fn [result] (swap! captured_ conj result) result)
-          sse-event {:status 200
-                     :headers
-                     {"Content-Type"  "text/event-stream"
-                      "Cache-Control" "no-cache, no-store"}
-                     :body   "data: hello \n\n"}
+          captured_    (atom []) ; [<send-success?> ...]
+          capture!     (fn [result] (swap! captured_ conj result) result)
+          sse-event    {:status 200
+                        :headers
+                        {"Content-Type"  "text/event-stream"
+                         "Cache-Control" "no-cache, no-store"}
+                        :body   "data: hello \n\n"}
           server
           (run-server
-            (fn [req]
-              (as-channel req
-                {:on-open  (fn [ch] (reset! ch_ ch))
-                 :on-close (fn [_ _]  (reset! fired-close_ true))}))
-            {:port 3474})]
+           (fn [req]
+             (as-channel req
+                         {:on-open  (fn [ch] (reset! ch_ ch))
+                          :on-close (fn [_ _]  (reset! fired-close_ true))}))
+           {:port 3474})]
 
       ;; open event-stream
       (http/get "http://localhost:3474/"
-        {:async? true
-         ;; Close client after 200ms
-         :timeout 100
-         :as :stream}
-        (fn cb [_] nil)
-        (fn cb [_] nil))
+                {:async?  true
+                 ;; Close client after 100ms
+                 :timeout 100
+                 :as      :stream}
+                (fn cb [_] nil)
+                (fn cb [_] nil))
 
       (Thread/sleep 50)
 


### PR DESCRIPTION
The change from #375 was preventing the close handler from firing. This was due to creating new AsyncChannel which did not have a close handler set.

To fix this we only create a new channel if the previous one was closed. This prevents the issue of closed channels being reopened and reused described in #375. But, still ensures the close handler for a channel is called correctly. 

Added a comment in the same style as #375 as it was quite useful for understanding the intent of the change. 

I've tested this with the minimum repro described in issue #578 and it works. However, I am assuming my understanding of #375 is correct and the issue was specifically to do with re-opening closed connections. 

I'm going to do some more aggressive testing on the demo app where I ran into the problem originally, flood it with requests etc, see if anything weird happens.
