### PR TITLE
Draft: throw exception on arrays that are too big to allocate

### DIFF
--- a/src/java/org/httpkit/ArrayTooLargeException.java
+++ b/src/java/org/httpkit/ArrayTooLargeException.java
@@ -1,0 +1,9 @@
+package org.httpkit;
+
+import java.lang.RuntimeException;
+
+public class ArrayTooLargeException extends RuntimeException {
+    public ArrayTooLargeException(String message) {
+        super(message);
+    }
+}

--- a/src/java/org/httpkit/DynamicBytes.java
+++ b/src/java/org/httpkit/DynamicBytes.java
@@ -1,7 +1,9 @@
 package org.httpkit;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import org.httpkit.ArrayTooLargeException;
 
 public class DynamicBytes {
     private byte[] data;
@@ -13,11 +15,11 @@ public class DynamicBytes {
 
     private void expandIfNeeded(int more) {
         if (idx + more > data.length) {
-            int after = (int) ((idx + more) * 1.33);
-            // String msg = "expand memory, from " + data.length + " to " +
-            // after + "; need " + more;
-            // System.out.println(msg);
-            data = Arrays.copyOf(data, after);
+            long after = (int) ((idx + more) * 1.33);
+            if (after >= Integer.MAX_VALUE) {
+                throw new ArrayTooLargeException("Cannot expand array: Size " + after + " exceeds java limits");
+            }
+            data = Arrays.copyOf(data, (int)after);
         }
     }
 

--- a/src/java/org/httpkit/client/RespListener.java
+++ b/src/java/org/httpkit/client/RespListener.java
@@ -1,20 +1,21 @@
 package org.httpkit.client;
 
-import org.httpkit.*;
+import static org.httpkit.HttpUtils.CONTENT_ENCODING;
+import static org.httpkit.HttpUtils.CONTENT_TYPE;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ProtocolException;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
+import java.util.zip.Deflater;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
-import java.util.zip.Deflater;
 import java.util.zip.InflaterInputStream;
 
-import static org.httpkit.HttpUtils.CONTENT_ENCODING;
-import static org.httpkit.HttpUtils.CONTENT_TYPE;
+import org.httpkit.*;
 
 class Handler implements Runnable {
 
@@ -158,7 +159,7 @@ public class RespListener implements IRespListener {
                     pool.submit(new Handler(handler, status.getCode(), headers, is));
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | ArrayTooLargeException e) {
             handler.onThrowable(e);
         }
     }


### PR DESCRIPTION
This is just a sample of one way to mitigate [this](https://github.com/http-kit/http-kit/issues/581). I don't know if it's good.

I think maybe subclassing IOException instead of using a RuntimeException is best but then you have to propagate it everywhere.