### PR TITLE
Validate the port sent in the Host header

### DIFF
--- a/src/java/org/httpkit/server/HttpRequest.java
+++ b/src/java/org/httpkit/server/HttpRequest.java
@@ -92,7 +92,13 @@ public class HttpRequest {
             int idx = h.lastIndexOf(':');
             if (idx != -1 && idx > ipv6end) {
                 this.serverName = h.substring(0, idx);
-                serverPort = Integer.valueOf(h.substring(idx + 1));
+                String serverPortCandidate = h.substring(idx + 1);
+                if (!serverPortCandidate.isEmpty()) {
+                    try {
+                        serverPort = Integer.parseInt(serverPortCandidate);
+                    } catch (Exception ignore) {
+                    }
+                }
             } else {
                 this.serverName = h;
             }


### PR DESCRIPTION
Issue:
http-kit does not validate the port it attempts to extract from the Host header and as such a malformed port results in some errors thrown. This occurs when it is empty or when it is anything other than numeric. Examples:
```
curl -v localhost:3000/api/status -H "host: localhost:"
curl -v localhost:3000/api/status -H "host: localhost:()"
curl -v localhost:3000/api/status -H "host: localhost:es"
```
Resulting in:
```
java.lang.NumberFormatException: For input string: "es"
  at java.base/java. lang.NumberFormatException.forInputString(NumberFormatException.java:67)
  at java.base/java.lang.Integer.parseInt(Integer.java:662)
  at java.base/java.lang.Integer.value0f(Integer.java:989)
  at org.httpkit.server.HttpRequest.setHeaders(HttpRequest.java:83)
  at org.httpkit.server.HttpDecoder.readHeaders(HttpDecoder.java:269)
  at org.httpkit.server.HttpDecoder.decode(HttpDecoder.java:186)
  at org.httpkit.server.HttpServer.decodeHttp(HttpServer.java:173)
  at org.httpkit.server.HttpServer.doRead(HttpServer.java:258)
  at org.httpkit.server.HttpServer.run(HttpServer.java:378)
  at java.base/java. lang.Thread. run(Thread.java:1583)
```

Fix:
Validate that the port is not empty and if we fail to parse it ignore the error and continue decoding the request