### PR TITLE
Add function and method to join the server thread

### DIFF
--- a/src/java/org/httpkit/server/HttpServer.java
+++ b/src/java/org/httpkit/server/HttpServer.java
@@ -543,4 +543,13 @@ public class HttpServer implements Runnable {
             warnLogger.log(String.format("failed to close %s", closable.getClass().getName()), ex);
         }
     }
+
+    /**
+     * Joins the thread in which the server runs; this will block until the server is stopped.
+     *
+     * @throws InterruptedException
+     */
+    public void join() throws InterruptedException {
+        serverThread.join();
+    }
 }

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -439,3 +439,8 @@
      (ring-handler rreq
        (fn respond* [rresp] (respond (ring-websocket-resp rreq rresp)))
        raise))))
+
+(defn join-server
+  "Joins the server, which will block the current thread until the server is stopped."
+  [^HttpServer server]
+  (.join server))

--- a/test/org/httpkit/server_test.clj
+++ b/test/org/httpkit/server_test.clj
@@ -639,8 +639,7 @@
 
                  (reset! *state :after)
                  (.countDown after-latch))]
-    (doto (Thread. joiner)
-      .start)
+    (.start (Thread. joiner))
 
     (.await before-latch)
 


### PR DESCRIPTION
This adds a `join` method to the HttpServer class, which will block until the server is shutdown. 
 
In addition, a `join-server` function was added to org.httpkit.server.

Fixes #588 