### PR TITLE
Specifying number of workers in NioClientSocketChannelFactory

### DIFF
--- a/test/java/org/httpkit/ws/WebSocketClient.java
+++ b/test/java/org/httpkit/ws/WebSocketClient.java
@@ -35,7 +35,7 @@ public class WebSocketClient {
 
     public WebSocketClient(String url) throws Exception {
         bootstrap = new ClientBootstrap(new NioClientSocketChannelFactory(
-                Executors.newFixedThreadPool(1), Executors.newFixedThreadPool(1)));
+                Executors.newFixedThreadPool(1), Executors.newFixedThreadPool(1), 1, 1));
         this.uri = new URI(url);
         HashMap<String, String> customHeaders = new HashMap<String, String>();
         final WebSocketClientHandshaker handshaker = new WebSocketClientHandshakerFactory()


### PR DESCRIPTION
The default is double the available cpu cores

This seems to fix #576

I ran the tests using `lein test` an _not_ `rake` - hopefully that doesn't change anything