### PR TITLE
Encode numbers correctly in MultipartEntity

### DIFF
--- a/src/java/org/httpkit/client/MultipartEntity.java
+++ b/src/java/org/httpkit/client/MultipartEntity.java
@@ -72,7 +72,7 @@ public class MultipartEntity {
                 byte[] contentBytes = (byte[])e.content;
                 bytes.append(contentBytes, contentBytes.length);
             } else if (e.content instanceof Number) {
-                bytes.append(e.toString(), HttpUtils.UTF_8);
+                bytes.append(e.content.toString(), HttpUtils.UTF_8);
             } else
                 throw new IllegalArgumentException("Unknown parameter type " + e.content.getClass().getName() + " of parameter " + e.name + ". Try to pass a string.");
             bytes.append(HttpUtils.CR, HttpUtils.LF);


### PR DESCRIPTION
In http-kit 2.3.0 a request with multipart form data sends numbers incorrectly. Here's an example:

I'm trying to upload a pdf file along with a "chat_id" number.
``` clojure
(require '[org.httpkit.client :as http])

(def res @(http/request {:url "https://avena1.requestcatcher.com/test"
                         :method :post
                         :multipart [{:name "chat_id"
                                      :content 144400000}
                                     {:name "document"
                                      :content pdf-bytes
                                      :filename "document.pdf"}]}))
```

`pdf-bytes` is a byte array with the contents of the file I want to upload. After running that, the server gets the following data in the `chat_id` part:

```
------HttpKitFormBoundary1744501484128

Content-Disposition: form-data; name="chat_id"



org.httpkit.client.MultipartEntity@31d2f46e
```

It's sending the `.toString()` value of the `MultipartEntity` object instead of the actual number. If I change `chat_id` to a string ("144400000") it works correctly:

```
------HttpKitFormBoundary1744504794048

Content-Disposition: form-data; name="chat_id"



144400000
```

 The solution seems to be really easy, just convert to string the actual number, not the `MultipartEntity` object.