### PR TITLE
Make RespListener immediately stream response

### DIFF
--- a/src/java/org/httpkit/client/Decoder.java
+++ b/src/java/org/httpkit/client/Decoder.java
@@ -160,6 +160,27 @@ public class Decoder {
         }
     }
 
+    private int parseContentLength() {
+        String cl = HttpUtils.getStringValue(headers, CONTENT_LENGTH);
+        if (cl == null) {
+            // response does not have content length
+            // it either has no body or is variable length
+            return -1;
+        }
+
+        try {
+          return Integer.parseInt(cl);
+        } catch (NumberFormatException ex) {
+          long parsed = Long.parseLong(cl);
+          if (parsed > Integer.MAX_VALUE) {
+            // Content is is larger that Integer.MAX_VALUE
+            // Let's pretend it has variable length.
+            return -1;
+          }
+          throw ex;
+        }
+    }
+
     private void readHeaders(ByteBuffer buffer) throws LineTooLargeException, AbortException, ProtocolException {
         String line = lineReader.readLine(buffer);
         while (line != null && !line.isEmpty()) {
@@ -180,14 +201,15 @@ public class Decoder {
             if (headers.containsKey(TRAILER))
               chunkTrailerExpected = true;
         } else {
-            String cl = HttpUtils.getStringValue(headers, CONTENT_LENGTH);
-            if (cl != null) {
-                readRemaining = Integer.parseInt(cl);
+            int cl = parseContentLength();
+            if (cl >= 0) {
+                readRemaining = cl;
                 if (readRemaining == 0) {
                     state = ALL_READ;
                 } else {
                     state = READ_FIXED_LENGTH_CONTENT;
                 }
+
             } else if (emptyBodyExpected) {
                 state = ALL_READ;
             } else {

--- a/src/java/org/httpkit/client/RespListener.java
+++ b/src/java/org/httpkit/client/RespListener.java
@@ -75,7 +75,6 @@ public class RespListener implements IRespListener {
             return body;
         }
 
-        encoding = encoding.toLowerCase();
         BytesInputStream bis = new BytesInputStream(body.get(), body.length());
         InputStream is =
             ResponseCompression.createDecompressingStream(bis, compressionType);
@@ -109,8 +108,6 @@ public class RespListener implements IRespListener {
         this.handler = handler;
         this.coercion = coercion;
         this.pool = pool;
-
-
     }
 
     private OutputStream startStreamingResponse(byte[] firstBytes) throws AbortException {

--- a/src/java/org/httpkit/client/RespListener.java
+++ b/src/java/org/httpkit/client/RespListener.java
@@ -11,10 +11,6 @@ import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.Inflater;
-import java.util.zip.Deflater;
-import java.util.zip.InflaterInputStream;
 
 import static org.httpkit.HttpUtils.CONTENT_ENCODING;
 import static org.httpkit.HttpUtils.CONTENT_TYPE;
@@ -73,32 +69,16 @@ public class RespListener implements IRespListener {
 
     private DynamicBytes unzipBody() throws IOException {
         String encoding = HttpUtils.getStringValue(headers, CONTENT_ENCODING);
-        if (encoding == null || body.length() == 0) {
+        ResponseCompression.Type compressionType =
+            ResponseCompression.detect(encoding, body.get());
+        if (compressionType == ResponseCompression.Type.NONE) {
             return body;
         }
 
         encoding = encoding.toLowerCase();
         BytesInputStream bis = new BytesInputStream(body.get(), body.length());
-        InputStream is;
-
-        if ("gzip".equals(encoding) || "x-gzip".equals(encoding)) {
-            is = new GZIPInputStream(bis);
-        } else if ("deflate".equals(encoding) || "x-deflate".equals(encoding)) {
-            // http://stackoverflow.com/questions/3932117/handling-http-contentencoding-deflate
-	    final int i1 = body.get()[0];
-	    final int i2 = body.get()[1];
-	    boolean nowrap = true;
-	    final int b1 = i1 & 0xFF;
-	    final int compressionMethod = b1 & 0xF;
-	    final int compressionInfo = b1 >> 4 & 0xF;
-	    final int b2 = i2 & 0xFF;
-	    if (compressionMethod == Deflater.DEFLATED && compressionInfo <= 7 && ((b1 << 8) | b2) % 31 == 0) {
-		nowrap = false;
-	    }
-            is = new InflaterInputStream(bis, new Inflater(nowrap));
-        } else {
-            return body; // not compressed
-        }
+        InputStream is =
+            ResponseCompression.createDecompressingStream(bis, compressionType);
 
         DynamicBytes unzipped = new DynamicBytes(body.length() * 5);
         byte[] buffer = new byte[4096];
@@ -133,11 +113,23 @@ public class RespListener implements IRespListener {
 
     }
 
-    private OutputStream startStreamingResponse() throws AbortException {
+    private OutputStream startStreamingResponse(byte[] firstBytes) throws AbortException {
         try {
             PipedInputStream is = new PipedInputStream(1024 * 8);
             PipedOutputStream os = new PipedOutputStream(is);
-            pool.submit(new Handler(handler, status.getCode(), headers, is));
+            // Immediately write to output stream so that GZIPInputStream doesn't block
+            os.write(firstBytes, 0, firstBytes.length);
+
+            // create input stream that handles compression if necessary
+            String encoding = HttpUtils.getStringValue(headers, CONTENT_ENCODING);
+            ResponseCompression.Type compressionType =
+                ResponseCompression.detect(encoding, firstBytes);
+            InputStream handlerStream =
+                ResponseCompression.createDecompressingStream(is, compressionType);
+
+            pool.submit(
+                new Handler(handler, status.getCode(), headers, handlerStream)
+            );
             return os;
         } catch (IOException ex) {
             throw new AbortException("Failed to start streaming response");
@@ -146,7 +138,8 @@ public class RespListener implements IRespListener {
 
     private void streamResponseChunk(byte[] buf, int length) throws AbortException {
         if (responseStreamer == null) {
-            responseStreamer = startStreamingResponse();
+            responseStreamer = startStreamingResponse(buf);
+            return;
         }
         try {
             responseStreamer.write(buf, 0, length);

--- a/src/java/org/httpkit/client/ResponseCompression.java
+++ b/src/java/org/httpkit/client/ResponseCompression.java
@@ -1,0 +1,154 @@
+package org.httpkit.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.Inflater;
+import java.util.zip.Deflater;
+import java.util.zip.InflaterInputStream;
+
+class ResponseCompression {
+    
+    protected enum Type {
+        NONE,
+        GZIP,
+        DEFLATE,
+        DEFLATE_NO_WRAP
+    }
+    
+    /**
+     * Detects the compression type based on Content-Encoding header
+     * and optionally peeking at the first few bytes for DEFLATE detection.
+     * 
+     * @param encoding The Content-Encoding header value (can be null)
+     * @param firstBytes Optional first 2 bytes for DEFLATE detection.
+     * (can be null, empty, or more than 2)
+     * @return The detected Type
+     */
+    protected static Type detect(String encoding, byte[] firstBytes) {
+        if (encoding == null || encoding.trim().isEmpty()) {
+            return Type.NONE;
+        }
+        
+        encoding = encoding.toLowerCase().trim();
+        
+        // Handle GZIP types
+        if ("gzip".equals(encoding) || "x-gzip".equals(encoding)) {
+            return Type.GZIP;
+        }
+        
+        // Handle DEFLATE types - need to examine the firstBytes to distinguish
+        if ("deflate".equals(encoding) || "x-deflate".equals(encoding)) {
+            if (firstBytes == null || firstBytes.length < 2) {
+                // Not enough data to determine, default to DEFLATE_NO_WRAP
+                // which is the more common case for HTTP
+                return Type.DEFLATE_NO_WRAP;
+            }
+            
+            return detectDeflateType(firstBytes);
+        }
+        
+        // Unknown encoding, treat as not compressed
+        return Type.NONE;
+    }
+
+    /**
+     * Examines the first two bytes to determine DEFLATE type.
+     * Based on RFC 1950 (zlib) and RFC 1951 (DEFLATE).
+     * 
+     * See http://stackoverflow.com/questions/3932117/handling-http-contentencoding-deflate
+     *
+     * @param firstBytes The first body bytes (must have at least 2 bytes)
+     * @return The specific DEFLATE compression type
+     */
+    private static Type detectDeflateType(byte[] firstBytes) {
+        final int i1 = firstBytes[0] & 0xFF;  // First byte as unsigned
+        final int i2 = firstBytes[1] & 0xFF;  // Second byte as unsigned
+        
+        // Check for zlib header (RFC 1950)
+        // CM (Compression Method) bits 0-3
+        // CINFO (Compression Info) bits 4-7
+        final int compressionMethod = i1 & 0x0F;
+        final int compressionInfo = (i1 >> 4) & 0x0F;
+        
+        // Check if it's a valid zlib header
+        // CM must be 8 (DEFLATE), CINFO must be <= 7 (window size <= 32K)
+        // FCHECK bits must form a multiple of 31
+        if (compressionMethod == Deflater.DEFLATED && compressionInfo <= 7 && 
+            ((i1 << 8) | i2) % 31 == 0) {
+            return Type.DEFLATE;  // zlib wrapped (with header)
+        }
+        
+        // Otherwise, it's raw DEFLATE (no wrap)
+        return Type.DEFLATE_NO_WRAP;
+    }
+    
+    /**
+     * Creates an appropriate InputStream for the given compression type.
+     * This is a helper method that can be used when you have the complete body.
+     * 
+     * @param baseStream The base InputStream (e.g., ByteArrayInputStream)
+     * @param type The compression type
+     * @return A decompressing InputStream, or the base stream if NONE
+     */
+    protected static InputStream createDecompressingStream(
+            InputStream baseStream, 
+            Type type) throws IOException {
+        
+        switch (type) {
+            case GZIP:
+                return new GZIPInputStream(baseStream);
+                
+            case DEFLATE:
+                // zlib format (with header)
+                return new InflaterInputStream(baseStream);
+                
+            case DEFLATE_NO_WRAP:
+                // Raw DEFLATE format
+                return new InflaterInputStream(
+                    baseStream, 
+                    new Inflater(true));
+                
+            case NONE:
+            default:
+                return baseStream;
+        }
+    }
+    
+    /**
+     * Helper method to detect compression type from response parts.
+     * Useful for streaming scenarios where you might have headers but not the full body yet.
+     * 
+     * @param encoding The Content-Encoding header
+     * @param firstChunk The first chunk of body data (optional)
+     * @return The detected compression type
+     */
+    public static Type fromStreamingResponse(
+            String encoding, 
+            byte[] firstChunk) {
+        
+        if (encoding == null || encoding.trim().isEmpty()) {
+            return Type.NONE;
+        }
+        
+        encoding = encoding.toLowerCase().trim();
+        
+        if ("gzip".equals(encoding) || "x-gzip".equals(encoding)) {
+            return Type.GZIP;
+        }
+        
+        if ("deflate".equals(encoding) || "x-deflate".equals(encoding)) {
+            // For streaming, we need to peek at the first chunk
+            if (firstChunk == null || firstChunk.length < 2) {
+                // Can't determine yet - return a special value or default
+                // Using DEFLATE_NO_WRAP as default since it's more common
+                return Type.DEFLATE_NO_WRAP;
+            }
+            
+            return detectDeflateType(firstChunk);
+        }
+        
+        return Type.NONE;
+    }
+}

--- a/src/java/org/httpkit/client/ResponseCompression.java
+++ b/src/java/org/httpkit/client/ResponseCompression.java
@@ -115,40 +115,4 @@ class ResponseCompression {
                 return baseStream;
         }
     }
-    
-    /**
-     * Helper method to detect compression type from response parts.
-     * Useful for streaming scenarios where you might have headers but not the full body yet.
-     * 
-     * @param encoding The Content-Encoding header
-     * @param firstChunk The first chunk of body data (optional)
-     * @return The detected compression type
-     */
-    public static Type fromStreamingResponse(
-            String encoding, 
-            byte[] firstChunk) {
-        
-        if (encoding == null || encoding.trim().isEmpty()) {
-            return Type.NONE;
-        }
-        
-        encoding = encoding.toLowerCase().trim();
-        
-        if ("gzip".equals(encoding) || "x-gzip".equals(encoding)) {
-            return Type.GZIP;
-        }
-        
-        if ("deflate".equals(encoding) || "x-deflate".equals(encoding)) {
-            // For streaming, we need to peek at the first chunk
-            if (firstChunk == null || firstChunk.length < 2) {
-                // Can't determine yet - return a special value or default
-                // Using DEFLATE_NO_WRAP as default since it's more common
-                return Type.DEFLATE_NO_WRAP;
-            }
-            
-            return detectDeflateType(firstChunk);
-        }
-        
-        return Type.NONE;
-    }
 }

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -101,6 +101,15 @@
 
   (GET "/test-header" [] (fn [{:keys [headers]}] (str (get headers "test-header"))))
   (GET "/zip"         [] (fn [req] {:body "hello"}))
+  (GET "/manual-gzip" []
+    (fn [req]
+      (let [content "This is manually gzipped content"
+            compressed (gzip-compress content)]
+        {:status 200
+         :body (java.io.ByteArrayInputStream. compressed)
+         :headers {"Content-Type" "text/plain"
+                   "Content-Encoding" "gzip"
+                   "Content-Length" (str (alength compressed))}})))
 
   (GET "/accept-encoding" []
     (fn [req]
@@ -619,6 +628,14 @@
 
 (deftest zip
   (is (instance? DynamicBytes (:body @(hkc/get "http://localhost:4347/zip" {:as :none})))))
+
+(deftest gzip-decompression
+  (testing "Client correctly decompresses gzip response in text mode"
+    (let [{:keys [body]} @(hkc/get "http://localhost:4347/manual-gzip" {:as :text})]
+      (is (= "This is manually gzipped content" body))))
+  (testing "Client correctly decompresses gzip response in stream mode"
+    (let [{:keys [body]} @(hkc/get "http://localhost:4347/manual-gzip" {:as :stream})]
+      (is (= "This is manually gzipped content" (slurp body))))))
 
 (deftest adding-accept-encoding-header
   (testing "if no Accept-Encoding header present, and not explicitly disabling auto compressing response, Accept-encoding header is automatically appended"

--- a/test/org/httpkit/test_util.clj
+++ b/test/org/httpkit/test_util.clj
@@ -1,6 +1,7 @@
 (ns org.httpkit.test-util
   (:use clojure.test)
-  (:import [java.io File FileOutputStream FileInputStream]))
+  (:import [java.io File FileOutputStream FileInputStream ByteArrayOutputStream]
+           [java.util.zip GZIPOutputStream]))
 
 (defn- string-80k []
   (apply str (map char
@@ -44,3 +45,10 @@
 
 (defn close-handler [status]
   (reset! channel-closed true))
+
+(defn gzip-compress [s]
+  (let [baos (ByteArrayOutputStream.)
+        gzos (GZIPOutputStream. baos)]
+    (.write gzos (.getBytes s "UTF-8"))
+    (.close gzos)
+    (.toByteArray baos)))


### PR DESCRIPTION
Fixes #591 

### How to test

At the moment I'm not sure how to write a test for this, but you can use this Node.js script to start a server that for every request streams the words 'one', 'two', 'three'... 'hundred'.

```javascript
const http = require('http');

const server = http.createServer((req, res) => {
  // Set headers for SSE (Server-Sent Events) or plain text streaming
  res.writeHead(200, {
    'Content-Type': 'text/plain',
    'Transfer-Encoding': 'chunked',
    'Cache-Control': 'no-cache',
    'Connection': 'keep-alive'
  });

  // Function to send numbers with delay
  async function streamNumbers() {
    for (let i = 1; i <= 100; i++) {
      const word = numberToWord(i);
      // Write the word followed by a comma and space (except the last one)
      res.write(`${word}${i < 100 ? ', ' : ''}`);
      
      // Add a delay to simulate processing time (250ms)
      await new Promise(resolve => setTimeout(resolve, 250));
    }
    
    // End the response when done
    res.end();
  }

  // Start streaming
  streamNumbers().catch(err => {
    console.error('Stream error:', err);
    res.end();
  });
});

// Helper function to convert numbers to words
function numberToWord(num) {
  const units = ['', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
  const teens = ['ten', 'eleven', 'twelve', 'thirteen', 'fourteen', 'fifteen', 'sixteen', 
                'seventeen', 'eighteen', 'nineteen'];
  const tens = ['', '', 'twenty', 'thirty', 'forty', 'fifty', 'sixty', 'seventy', 
               'eighty', 'ninety'];

  if (num === 0) return 'zero';
  if (num < 10) return units[num];
  if (num < 20) return teens[num - 10];
  if (num < 100) {
    const ten = Math.floor(num / 10);
    const unit = num % 10;
    return tens[ten] + (unit ? '-' + units[unit] : '');
  }
  return num.toString(); // For 100+ just return the number
}

const PORT = 3000;
server.listen(PORT, () => {
  console.log(`Server running at http://localhost:${PORT}`);
});
```

Then on a REPL use this namespace to verify that the chunks get received one by one:

``` clojure
(ns stream-responses
  (:require [org.httpkit.client :as hk]))

(defn print-streaming-bytes
  "Reads bytes from an InputStream and prints them as they arrive."
  [input-stream]
  (let [buffer-size 256
        encoding "UTF-8"
        buffer (byte-array buffer-size)]
    (try
      (loop []
        (let [bytes-read (.read input-stream buffer)]
          (when (pos? bytes-read)
            (let [chunk (String. buffer 0 bytes-read encoding)]
              (print chunk)
              (flush)
              (recur)))))
      (catch Exception e
        (println "Error reading stream:" (.getMessage e)))
      (finally
        (.close input-stream)))))

(defn run [url]
  (let [res @(hk/get url {:as :stream})]
    (print-streaming-bytes (:body res))))
```

Usage:

```clojure
(require 'stream-responses)
(in-ns 'stream-responses)
(run "http://localhost:3000")
;; => one,
;; => two, three, four,
;; =>five,
;; => ...
```