### PR TITLE
Remove default Content-Length: 0 for bodyless requests

### DIFF
--- a/src/java/org/httpkit/client/HttpClient.java
+++ b/src/java/org/httpkit/client/HttpClient.java
@@ -411,10 +411,10 @@ public class HttpClient implements Runnable {
         ByteBuffer bodyBuffer = HttpUtils.bodyBuffer(body);
 
         if (body != null) {
-            headers.putOrReplace("Content-Length", Integer.toString(bodyBuffer.remaining()));
-        } else {
-            headers.putOrReplace("Content-Length", "0");
+            String value = Integer.toString(bodyBuffer.remaining());
+            headers.putOrReplace("Content-Length", value);
         }
+
         DynamicBytes bytes = new DynamicBytes(196);
         bytes.append(method.toString()).append(SP).append(path);
         bytes.append(" HTTP/1.1\r\n");

--- a/test/org/httpkit/client_test.clj
+++ b/test/org/httpkit/client_test.clj
@@ -107,6 +107,9 @@
       {:status  200 :body ""
        :headers {"x-sent-accept-encoding" (get-in req [:headers "accept-encoding"])}}))
 
+  (GET "/content-length" [] (fn [{:keys [headers]}] (str (get headers "content-length"))))
+  (POST "/content-length" [] (fn [{:keys [headers]}] (str (get headers "content-length"))))
+
   (ANY "*" [] {:status 404 :body ""}))
 
 (defonce servers_ (atom nil))
@@ -516,6 +519,16 @@
       (is (= received expected)))))
 
 (defn- utf8 [^String s] (ByteBuffer/wrap (.getBytes s "UTF-8")))
+
+(deftest test-sent-content-length
+  ;; fix #583
+  (is (= ""  (:body @(hkc/get  "http://127.0.0.1:14347/content-length"))))
+  (is (= ""  (:body @(hkc/head "http://127.0.0.1:14347/content-length"))))
+  (is (= ""  (:body @(hkc/post "http://127.0.0.1:14347/content-length"))))
+  (is (= "3" (:body @(hkc/post "http://127.0.0.1:14347/content-length"
+                               {:body "123"}))))
+  (is (= "0" (:body @(hkc/post "http://127.0.0.1:14347/content-length"
+                               {:headers {"content-length" "0"}})))))
 
 (defn- decode [method buffer]
   (let [out (atom [])


### PR DESCRIPTION
Fixes #583 

I could not find any good reason for the client to send `Content-Length: 0` in a bodyless request. This behavior is unnecessary and non-compliant with the HTTP/1.1 best practices: 

- RFC 7230 (Section 3.3.2) states that `Content-Length` should only be used when a message body is present.
- Bodyless methods like GET or HEAD should omit `Content-Length` entirely, as its absence implies no body.
- Some servers or proxies may misinterpret `Content-Length: 0` as an empty body rather than no body, leading to edge-case issues.

 Users who explicitly need this header (e.g., for legacy server compatibility) can still add it manually.