### PR TITLE
Fix #366 - httpclient get, had to force {:as :stream} since otherwise .xlsx was corrupted

### DIFF
--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -67,6 +67,22 @@ public class HttpUtils {
     public static final String CONTENT_TYPE = "content-type";
     public static final String CONTENT_LENGTH = "content-length";
 
+    public static final Set<String> NON_TEXT_CONTENT_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",   // .docx
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.template",   // .dotx
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",         // .xlsx
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.template",      // .xltx
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation", // .pptx
+            "application/vnd.openxmlformats-officedocument.presentationml.slide",        // .sldx
+            "application/vnd.openxmlformats-officedocument.presentationml.slideshow",    // .ppsx
+            "application/vnd.openxmlformats-officedocument.presentationml.template",     // .potx
+            "application/vnd.oasis.opendocument.text",                                   // .odt
+            "application/vnd.oasis.opendocument.text-template",                          // .ott
+            "application/vnd.oasis.opendocument.text-web",                               // .oth
+            "application/vnd.oasis.opendocument.text-master"                             // .odm
+    )));
+
+
     public static final String CHUNKED = "chunked";
     public static final String TRAILER = "trailer";
 

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -68,6 +68,7 @@ public class HttpUtils {
     public static final String CONTENT_LENGTH = "content-length";
 
     public static final Set<String> NON_TEXT_CONTENT_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "image/svg+xml",                                                             // .svg
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",   // .docx
             "application/vnd.openxmlformats-officedocument.wordprocessingml.template",   // .dotx
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",         // .xlsx

--- a/src/java/org/httpkit/client/RespListener.java
+++ b/src/java/org/httpkit/client/RespListener.java
@@ -15,6 +15,7 @@ import java.util.zip.InflaterInputStream;
 
 import static org.httpkit.HttpUtils.CONTENT_ENCODING;
 import static org.httpkit.HttpUtils.CONTENT_TYPE;
+import static org.httpkit.HttpUtils.NON_TEXT_CONTENT_TYPES;
 
 class Handler implements Runnable {
 
@@ -59,7 +60,11 @@ public class RespListener implements IRespListener {
             if (type != null) {
                 type = type.toLowerCase();
                 // TODO may miss something
-                return type.contains("text") || type.contains("json") || type.contains("xml");
+                if (NON_TEXT_CONTENT_TYPES.contains(type)) {
+                    return false;
+                } else {
+                    return type.contains("text") || type.contains("json") || type.contains("xml");
+                }
             } else {
                 return false;
             }


### PR DESCRIPTION
Resolved #366 this via dedicated set of types that should not be treated as text. 
I've also discovered some other file formats that contain text or xml substring and added them to the set.

Should I also add tests to check this behavior?

This may be only my preference but I suggest to refactor the `isText()` to reduce nesting.
<details>

<summary>suggested `isText()` code</summary>

```java
 private boolean isText() {
        if (status.getCode() != 200) {
            return true;
        } // non 200: treat as text
        String type = HttpUtils.getStringValue(headers, CONTENT_TYPE);

        if (type == null) {
            return false;
        }

        type = type.toLowerCase();

        // TODO may miss something
        if (NON_TEXT_CONTENT_TYPES.contains(type)) {
            return false;
        } else {
            return type.contains("text") || type.contains("json") || type.contains("xml");
        }
    }
```
</details>