### PR TITLE
 [new] [server] [#226] Add :legacy-unsafe-remote-addr? option for secure IP handling (@ramblurr)

### DIFF
--- a/src/java/org/httpkit/server/HttpAtta.java
+++ b/src/java/org/httpkit/server/HttpAtta.java
@@ -2,8 +2,8 @@ package org.httpkit.server;
 
 public class HttpAtta extends ServerAtta {
 
-    public HttpAtta(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption) {
-        decoder = new HttpDecoder(maxBody, maxLine, proxyProtocolOption);
+    public HttpAtta(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption, boolean legacyUnsafeRemoteAddr) {
+        decoder = new HttpDecoder(maxBody, maxLine, proxyProtocolOption, legacyUnsafeRemoteAddr);
     }
 
     public final HttpDecoder decoder;

--- a/src/java/org/httpkit/server/HttpDecoder.java
+++ b/src/java/org/httpkit/server/HttpDecoder.java
@@ -60,10 +60,12 @@ public class HttpDecoder {
 
     private final int maxBody;
     private final LineReader lineReader;
+    private final boolean legacyUnsafeRemoteAddr;
 
-    public HttpDecoder(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption) {
+    public HttpDecoder(int maxBody, int maxLine, ProxyProtocolOption proxyProtocolOption, boolean legacyUnsafeRemoteAddr) {
         this.maxBody = maxBody;
         this.lineReader = new LineReader(maxLine);
+        this.legacyUnsafeRemoteAddr = legacyUnsafeRemoteAddr;
         this.proxyProtocolOption = (proxyProtocolOption == null)
             ? ProxyProtocolOption.DISABLED : proxyProtocolOption;
 
@@ -134,7 +136,7 @@ public class HttpDecoder {
                 if ("HTTP/1.0".equals(sb.substring(cStart, cEnd))) {
                     version = HTTP_1_0;
                 }
-                request = new HttpRequest(method, sb.substring(bStart, bEnd), version);
+                request = new HttpRequest(method, sb.substring(bStart, bEnd), version, legacyUnsafeRemoteAddr);
             } catch (Exception e) {
                 throw new ProtocolException("method not understand");
             }

--- a/test/java/org/httpkit/server/RingHandlerTest.java
+++ b/test/java/org/httpkit/server/RingHandlerTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 
 public class RingHandlerTest {
 
-    private HttpDecoder httpDecoder = new HttpDecoder(8388608, 4096, ProxyProtocolOption.DISABLED);
+    private HttpDecoder httpDecoder = new HttpDecoder(8388608, 4096, ProxyProtocolOption.DISABLED, true);
 
     @Test
     public void shouldUseExternalThreadPoolForExecution() throws InterruptedException, ProtocolException, LineTooLargeException, RequestTooLargeException {


### PR DESCRIPTION
Adds new server option to control :remote-addr population behavior.
When false, :remote-addr uses actual socket address instead of
X-Forwarded-For header, preventing IP spoofing attacks.

Defaults to true for backwards compatibility.
