### PR TITLE
avoid int overflow in DynamicBytes

### DIFF
--- a/src/java/org/httpkit/DynamicBytes.java
+++ b/src/java/org/httpkit/DynamicBytes.java
@@ -14,7 +14,8 @@ public class DynamicBytes {
 
     private void expandIfNeeded(int more) {
         if (idx + more > data.length) {
-            long after =  (long)((idx + more) * 1.33);
+            double after =  (((long)idx + more) * 1.33);
+            // java arrays are indexed by `int`
             if (after >= Integer.MAX_VALUE) {
                 throw new ContentTooLargeException("Cannot expand DynamicBytes array: requested size (" + after + ") exceeds java limits");
             }


### PR DESCRIPTION
Avoid overflow in DynamicBytes

- Promote idx to long before addition to prevent int overflow when computing (idx + more) * 1.33
- Keep double before allocating the array to make sure we didn't overflow
