### PR TITLE
Support SNI when `:insecure? true`

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -296,14 +296,13 @@ Value may be a delay. See also `make-client`."}
    & [callback]]
 
   (let [{:keys [url method headers body]} (coerce-req opts)
-        [sslengine client]
-        (if insecure?
-          [(ClientSslEngineFactory/trustAnybody) @legacy-client]
-          [(:sslengine opts)
-           (or
-             (force          client)
-             (force *default-client*)
-             (force  default-client))])
+        sslengine (if insecure?
+                    (ClientSslEngineFactory/trustAnybody)
+                    (:sslengine opts))
+        client (or
+                 (force          client)
+                 (force *default-client*)
+                 (force  default-client))
 
         deliver-resp
         (fn [resp]


### PR DESCRIPTION
This PR fixes the issue described in #607


I managed to create a test scenario, using containers, to reproduce the issue, but I didn't know how to transform that scenario into an actual test for application.

This scenario can [be seen here](https://github.com/souenzzo/http-kit/pull/1).
