### PR TITLE
[fix] [#609] make-client use the default-ssl-configurer, if available

### DIFF
--- a/src/org/httpkit/client.clj
+++ b/src/org/httpkit/client.clj
@@ -139,6 +139,13 @@
   (^SSLEngine [               ] (make-ssl-engine (SSLContext/getDefault)))
   (^SSLEngine [^SSLContext ctx] (.createSSLEngine ctx)))
 
+(def ^:private default-ssl-configurer
+  "SNI-capable SSL configurer, or nil."
+  (when (utils/java-version>= 8)
+    ;; Note "Gilardi scenario"
+    (require            'org.httpkit.sni-client)
+    (some-> (ns-resolve 'org.httpkit.sni-client 'ssl-configurer) deref)))
+
 (defn make-client
   "Returns an HttpClient with specified options:
     :max-connections    ; Max connection count, default is unlimited (-1)
@@ -156,7 +163,8 @@
            event-logger
            event-names
            bind-address
-           channel-factory]}]
+           channel-factory]
+    :or   {ssl-configurer default-ssl-configurer}}]
   (HttpClient.
    (or max-connections -1)
 
@@ -198,19 +206,12 @@
 
    bind-address))
 
-(def ^:private ssl-configurer
-  "SNI-capable SSL configurer, or nil."
-  (when (utils/java-version>= 8)
-    ;; Note "Gilardi scenario"
-    (require            'org.httpkit.sni-client)
-    (some-> (ns-resolve 'org.httpkit.sni-client 'ssl-configurer) deref)))
-
 ;; Normally only need one client per application - params can be configured per req
 (defonce  legacy-client (delay (HttpClient.)))
 (defonce default-client
   (delay
-    (if ssl-configurer
-      (make-client {:ssl-configurer ssl-configurer})
+    (if default-ssl-configurer
+      (make-client {})
       @legacy-client)))
 
 (defonce


### PR DESCRIPTION
Now `(make-client {})` is always equivalent to `default-client`

<details>
<summary> `ssl-configurer -> default-ssl-configurer` is a safe rename because it is private</summary>

I can't find any usage of `org.httpkit.client/ssl-configurer` in other libraries

https://grep.app/search?f.lang=Clojure&q=ssl-configurer
</details>

Edge case:
- if `default-ssl-configurer` is `nil` and you call `(make-client {})`, it will use `HttpClient$SSLEngineURIConfigurer/NOP`
- if `default-ssl-configurer` is `nil` and you call `(make-client {:ssl-configurer my-ssl})`, it will use `my-ssl`


