### PR TITLE
Update all CI actions versions

### DIFF
--- a/.github/workflows/graal-tests.yml
+++ b/.github/workflows/graal-tests.yml
@@ -18,7 +18,7 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: DeLaGuardo/setup-clojure@13.6
+      - uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           lein: latest
           bb: latest

--- a/.github/workflows/graal-tests.yml
+++ b/.github/workflows/graal-tests.yml
@@ -5,12 +5,12 @@ jobs:
   test:
     strategy:
       matrix:
-        java: ['17']
+        java: ['25']
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: graalvm/setup-graalvm@v1
         with:
           version: 'latest'
@@ -18,12 +18,12 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: DeLaGuardo/setup-clojure@12.5
+      - uses: DeLaGuardo/setup-clojure@13.6
         with:
           lein: latest
           bb: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: deps-${{ hashFiles('deps.edn') }}

--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -5,22 +5,22 @@ jobs:
   tests:
     strategy:
       matrix:
-        java: ['17', '19', '21']
+        java: ['17', '21', '25']
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
           java-version: ${{ matrix.java }}
 
-      - uses: DeLaGuardo/setup-clojure@12.5
+      - uses: DeLaGuardo/setup-clojure@13.6
         with:
           lein: latest
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache-deps
         with:
           path: ~/.m2/repository

--- a/.github/workflows/main-tests.yml
+++ b/.github/workflows/main-tests.yml
@@ -16,7 +16,7 @@ jobs:
           distribution: 'corretto'
           java-version: ${{ matrix.java }}
 
-      - uses: DeLaGuardo/setup-clojure@13.6
+      - uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           lein: latest
 


### PR DESCRIPTION
GraalVM@17 is unavailable to download (non-lts)
Corretto@19 is non-lts, replaced with 25.

Some :negative_squared_cross_mark:  because maven is unstable today.
