### PR TITLE
[server] WebSocket permessage-deflate (RFC 7692)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ native-test-0.0.1-standalone.build_artifacts.txt
 target
 .lein-repl-history
 /wiki/.git
+
+# clj CLI classpath cache
+.cpcache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@ This project uses [**Break Versioning**](https://www.taoensso.com/break-versioni
 
 ---
 
+# Unreleased
+
+## New: WebSocket `permessage-deflate` (RFC 7692)
+
+The server now accepts a client's `permessage-deflate` offer and compresses
+WebSocket messages with **context takeover**, so message N is compressed
+against messages 1..N-1. This is what makes it worth having for a stream of
+many small similar messages: compressing each message independently saves ~10%,
+while context takeover took a sample stream of 500 small JSON-ish messages from
+88 624 to 10 783 bytes (**-88%**).
+
+- Off unless the client offers it, so a connection that does not negotiate the
+  extension is byte-identical to before.
+- Bind `*websocket-compression?*` to false to refuse it. Worth doing when
+  payloads are already compressed (images, video), where deflate spends CPU to
+  make them slightly larger, or when per-connection memory matters more than
+  bandwidth -- context takeover keeps a deflate and an inflate window alive for
+  the life of each connection.
+- `*websocket-max-message-size*` bounds a message's size **after**
+  decompression. This is separate from `:max-ws`, which bounds the bytes
+  actually received and so says nothing about the size after inflation.
+
+A message whose compressed form is empty goes out as the single octet `0x00`
+per RFC 7692 7.2.3.6, not as zero bytes. Zero bytes round-trips fine on a fresh
+connection and desynchronises the stream mid-conversation, once there is
+compression history for it to corrupt.
+
+Not implemented: `server_max_window_bits`. `java.util.zip` does not expose
+zlib's windowBits, so the server cannot honour a smaller window and does not
+claim to -- the parameter is simply not echoed, which per RFC 7692 means a
+15-bit window. `client_max_window_bits` is accepted.
+
+---
+
 # `v2.9.0-beta4` (2026-07-31)
 
 - **Dependency**: [on Clojars](https://clojars.org/http-kit/versions/2.9.0-beta4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ per RFC 7692 7.2.3.6, not as zero bytes. Zero bytes round-trips fine on a fresh
 connection and desynchronises the stream mid-conversation, once there is
 compression history for it to corrupt.
 
-Not implemented: `server_max_window_bits`. `java.util.zip` does not expose
-zlib's windowBits, so the server cannot honour a smaller window and does not
-claim to -- the parameter is simply not echoed, which per RFC 7692 means a
-15-bit window. `client_max_window_bits` is accepted.
+Not implemented, and therefore DECLINED rather than silently accepted:
+`server_max_window_bits`. `java.util.zip` does not expose
+zlib's windowBits, so the server cannot honour a smaller window, and per RFC
+7692 7.1.2.1 a server that does not support the parameter declines the offer --
+accepting while omitting it is not valid, and would leave a client that sized
+its inflate window at 1 KiB reading 32 KiB-distance references.
+`client_max_window_bits` is accepted.
 
 ---
 

--- a/src/java/org/httpkit/HttpUtils.java
+++ b/src/java/org/httpkit/HttpUtils.java
@@ -659,12 +659,22 @@ public class HttpUtils {
     }
 
     public static ByteBuffer WsEncode(byte opcode, byte[] data, int length) {
+        return WsEncode(opcode, data, length, false);
+    }
+
+    /**
+     * @param rsv1 set the RSV1 bit, which under RFC 7692 (permessage-deflate)
+     *             marks the message as compressed. Only ever legal on the first
+     *             frame of a data message, and never on a control frame.
+     */
+    public static ByteBuffer WsEncode(byte opcode, byte[] data, int length, boolean rsv1) {
         if ((opcode & 0x08) != 0 && length > 125) {
             throw new IllegalArgumentException(
                     "Websocket control frame payload exceeds 125 bytes");
         }
         byte b0 = 0;
         b0 |= 1 << 7; // FIN
+        if (rsv1) b0 |= 0x40;
         b0 |= opcode;
         int headerLength = length <= 125 ? 2 : length <= 0xFFFF ? 4 : 10;
         ByteBuffer buffer = ByteBuffer.allocate(length + headerLength);
@@ -685,6 +695,6 @@ public class HttpUtils {
     }
 
     public static ByteBuffer WsEncode(byte opcode, byte[] data) {
-        return WsEncode(opcode, data, data.length);
+        return WsEncode(opcode, data, data.length, false);
     }
 }

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -47,6 +47,9 @@ public class AsyncChannel {
     // streaming
     private volatile boolean headerSent = false;
     private volatile boolean websocketUpgraded = false;
+    // Null unless permessage-deflate (RFC 7692) was negotiated. Guarded by the
+    // same monitor as send(), which is the only thing that touches it.
+    private PerMessageDeflate perMessageDeflate;
 
     // messages sent from a WebSocket client should be handled orderly by server
     // Changed from a Single Thread(IO event thread), no volatile needed
@@ -294,6 +297,14 @@ public class AsyncChannel {
             handler = closeHandler;
             ringHandler = closeRingHandler;
         }
+        // Deflater/Inflater hold native memory that is not reclaimed by GC
+        // promptly. A server holding many connections would otherwise leak it
+        // for as long as the objects stay reachable.
+        PerMessageDeflate pmd = getPerMessageDeflate();
+        if (pmd != null) {
+            setPerMessageDeflate(null);
+            pmd.end();
+        }
         if (handler != null) {
             handler.invoke(readable(status));
         }
@@ -341,6 +352,39 @@ public class AsyncChannel {
         return true;
     }
 
+    /**
+     * Install the negotiated permessage-deflate codec. Called once, from the
+     * handshake, before any frame is sent.
+     *
+     * <p>Also pushes it into the connection's decoder. The {@link WsAtta} that
+     * owns that decoder is created when the upgrade request is DECODED, which
+     * happens before the Ring handler and therefore before negotiation, so it
+     * cannot read the codec for itself -- both directions have to be wired from
+     * here, after there is something to wire.
+     */
+    public synchronized void setPerMessageDeflate(PerMessageDeflate pmd) {
+        this.perMessageDeflate = pmd;
+        Object atta = key.attachment();
+        if (atta instanceof WsAtta) {
+            ((WsAtta) atta).decoder.setPerMessageDeflate(pmd);
+        }
+    }
+
+    public synchronized PerMessageDeflate getPerMessageDeflate() {
+        return perMessageDeflate;
+    }
+
+    /** Frame a DATA payload, compressing it when the extension is active.
+     *  Control frames never come through here -- RFC 7692 6.1 forbids
+     *  compressing them. */
+    private ByteBuffer wsData(byte opcode, byte[] data, int length) {
+        if (perMessageDeflate != null) {
+            byte[] deflated = perMessageDeflate.compress(data, length);
+            return WsEncode(opcode, deflated, deflated.length, true);
+        }
+        return WsEncode(opcode, data, length);
+    }
+
     public synchronized boolean send(Object data, boolean close) throws IOException {
         if (closedRan.get()) {
             return false;
@@ -355,12 +399,14 @@ public class AsyncChannel {
             }
 
             if (data instanceof String) { // null is not allowed
-                server.tryWrite(key, WsEncode(OPCODE_TEXT, ((String) data).getBytes(UTF_8)));
+                byte[] bs = ((String) data).getBytes(UTF_8);
+                server.tryWrite(key, wsData(OPCODE_TEXT, bs, bs.length));
             } else if (data instanceof byte[]) {
-                server.tryWrite(key, WsEncode(OPCODE_BINARY, (byte[]) data));
+                byte[] bs = (byte[]) data;
+                server.tryWrite(key, wsData(OPCODE_BINARY, bs, bs.length));
             } else if (data instanceof InputStream) {
                 DynamicBytes bytes = readAll((InputStream) data);
-                server.tryWrite(key, WsEncode(OPCODE_BINARY, bytes.get(), bytes.length()));
+                server.tryWrite(key, wsData(OPCODE_BINARY, bytes.get(), bytes.length()));
             } else if (data instanceof Frame.PingFrame) {
                 server.tryWrite(key, WsEncode(OPCODE_PING, ((Frame) data).data));
             } else if (data instanceof Frame.PongFrame) {

--- a/src/java/org/httpkit/server/AsyncChannel.java
+++ b/src/java/org/httpkit/server/AsyncChannel.java
@@ -297,14 +297,7 @@ public class AsyncChannel {
             handler = closeHandler;
             ringHandler = closeRingHandler;
         }
-        // Deflater/Inflater hold native memory that is not reclaimed by GC
-        // promptly. A server holding many connections would otherwise leak it
-        // for as long as the objects stay reachable.
-        PerMessageDeflate pmd = getPerMessageDeflate();
-        if (pmd != null) {
-            setPerMessageDeflate(null);
-            pmd.end();
-        }
+        releasePerMessageDeflate();
         if (handler != null) {
             handler.invoke(readable(status));
         }
@@ -343,6 +336,7 @@ public class AsyncChannel {
         if (!websocket) {
             server.responseComplete(key);
         }
+        releasePerMessageDeflate();
         if (handler != null) {
             handler.invoke(readable(0)); // server close is 0
         }
@@ -350,6 +344,28 @@ public class AsyncChannel {
             ringHandler.invoke(status, reason);
         }
         return true;
+    }
+
+    /**
+     * Release the negotiated codec's native zlib state.
+     *
+     * <p>Called from BOTH close paths. It used to live only in {@code onClose},
+     * which leaked on every server-initiated close: {@code serverClose} sets
+     * {@code closedRan} itself, and {@code RingHandler} then suppresses
+     * {@code onClose} because the channel is already closed. That covers
+     * explicit close, send-and-close, the Ring WebSocket {@code -close},
+     * overload closure and timeouts -- so a retained closed channel held both
+     * a Deflater and an Inflater indefinitely.
+     *
+     * <p>{@code PerMessageDeflate.end()} is idempotent, so reaching here twice
+     * is harmless.
+     */
+    private void releasePerMessageDeflate() {
+        PerMessageDeflate pmd = getPerMessageDeflate();
+        if (pmd != null) {
+            setPerMessageDeflate(null);
+            pmd.end();
+        }
     }
 
     /**

--- a/src/java/org/httpkit/server/PerMessageDeflate.java
+++ b/src/java/org/httpkit/server/PerMessageDeflate.java
@@ -2,6 +2,8 @@ package org.httpkit.server;
 
 import org.httpkit.DynamicBytes;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
@@ -9,10 +11,17 @@ import java.util.zip.Inflater;
 /**
  * The "permessage-deflate" WebSocket extension, RFC 7692.
  *
- * <p>One instance per connection. Not thread-safe, and does not need to be:
- * outbound frames are serialised by {@code AsyncChannel.send}, which is
- * {@code synchronized}, and inbound frames are decoded on the single IO event
- * thread that owns the connection's {@link WsAtta}.
+ * <p>One instance per connection, and internally synchronized.
+ *
+ * <p>An earlier version claimed synchronization was unnecessary because
+ * outbound frames are serialised by {@code AsyncChannel.send} and inbound
+ * frames are decoded on the single IO event thread owning the connection's
+ * {@link WsAtta}. Both are true and neither covers SHUTDOWN: {@code onClose}
+ * and {@code serverClose} run on whatever thread closed the channel, and
+ * {@code HttpServer.stop} closes keys from the stopping thread while the
+ * selector may still be mid-decode. That put {@code Inflater.end()} in a race
+ * with {@code Inflater.inflate()} over native memory, which is not a
+ * misbehaving-parse problem but a JVM-integrity one.
  *
  * <h3>What is implemented</h3>
  *
@@ -52,6 +61,9 @@ public class PerMessageDeflate {
     private final boolean serverNoContextTakeover;
     private final boolean clientNoContextTakeover;
     private final int maxSize;
+    private boolean ended;
+
+    private static final byte[] EMPTY = new byte[0];
 
     private PerMessageDeflate(boolean serverNoContextTakeover,
                               boolean clientNoContextTakeover,
@@ -79,38 +91,64 @@ public class PerMessageDeflate {
         // The header is a comma-separated list of offers, each of which the
         // server may accept or skip. Take the first one we can satisfy.
         for (String candidate : offer.split(",")) {
-            String[] parts = candidate.trim().split(";");
+            // Limit -1: split() drops TRAILING empty strings by default, so
+            // "permessage-deflate;;" arrived here as a clean single-element
+            // array and the empty-parameter check below never saw it.
+            String[] parts = candidate.trim().split(";", -1);
             if (parts.length == 0 || !NAME.equalsIgnoreCase(parts[0].trim())) {
                 continue;
             }
 
             boolean serverNoCtx = false, clientNoCtx = false, acceptable = true;
-            for (int i = 1; i < parts.length; i++) {
+            // RFC 7692 7.1: "the negotiation offer contains multiple extension
+            // parameters with the same name" is grounds to DECLINE, so names
+            // are tracked rather than last-one-wins.
+            Set<String> seen = new HashSet<String>();
+
+            for (int i = 1; i < parts.length && acceptable; i++) {
                 String p = parts[i].trim();
-                if (p.isEmpty()) continue;
+                // An empty parameter (`permessage-deflate;;`) is not valid
+                // grammar; it used to be skipped.
+                if (p.isEmpty()) { acceptable = false; break; }
                 int eq = p.indexOf('=');
                 String key = (eq < 0 ? p : p.substring(0, eq)).trim();
                 String val = eq < 0 ? null : unquote(p.substring(eq + 1).trim());
 
+                if (!seen.add(key.toLowerCase())) { acceptable = false; break; }
+
                 if ("server_no_context_takeover".equalsIgnoreCase(key)) {
+                    // Takes no value. `server_no_context_takeover=x` is invalid.
+                    if (val != null) { acceptable = false; break; }
                     serverNoCtx = true;
                 } else if ("client_no_context_takeover".equalsIgnoreCase(key)) {
+                    if (val != null) { acceptable = false; break; }
                     clientNoCtx = true;
                 } else if ("client_max_window_bits".equalsIgnoreCase(key)) {
-                    // Accepted but not echoed: it constrains the CLIENT's
-                    // deflater, and our inflater copes with any legal window.
-                    if (val != null && !isWindowBits(val)) acceptable = false;
+                    // Constrains the CLIENT's deflater. Our Inflater copes with
+                    // any legal window, so an offer is acceptable either as a
+                    // bare hint or with a value -- but a malformed value is not.
+                    if (val != null && !isWindowBits(val)) { acceptable = false; break; }
                 } else if ("server_max_window_bits".equalsIgnoreCase(key)) {
-                    // Cannot be honoured (see class docs). If the client merely
-                    // offered it we decline the parameter by not echoing it,
-                    // which per RFC 7692 means a 15-bit window. A value we do
-                    // not understand makes the whole offer unacceptable.
-                    if (val != null && !isWindowBits(val)) acceptable = false;
+                    // DECLINE. java.util.zip does not expose zlib's windowBits,
+                    // so the server cannot honour a smaller window.
+                    //
+                    // This used to accept the offer and simply omit the
+                    // parameter from the response. That is not a valid
+                    // acceptance: RFC 7692 7.1.2.1 says "a server declines an
+                    // extension negotiation offer with this parameter if the
+                    // server doesn't support it", and accepting requires
+                    // echoing the parameter with the same or a smaller value.
+                    // A client that offered server_max_window_bits=10 may size
+                    // its inflate window at 1 KiB while we emit 32 KiB-distance
+                    // references -- silent corruption, not a failed handshake.
+                    acceptable = false;
+                    break;
                 } else {
                     // An unknown parameter must make the offer unacceptable
                     // rather than be ignored -- ignoring it would mean agreeing
                     // to terms we did not implement.
                     acceptable = false;
+                    break;
                 }
             }
             if (acceptable) {
@@ -120,13 +158,17 @@ public class PerMessageDeflate {
         return null;
     }
 
+    /** RFC 7692: 1*DIGIT, a decimal integer 8..15 without leading zeroes.
+     *  Integer.parseInt is too lax on its own -- it accepts "+8" and "08". */
     private static boolean isWindowBits(String s) {
-        try {
-            int n = Integer.parseInt(s);
-            return n >= 8 && n <= 15;
-        } catch (NumberFormatException e) {
-            return false;
+        if (s.isEmpty() || s.length() > 2) return false;
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c < '0' || c > '9') return false;
         }
+        if (s.length() > 1 && s.charAt(0) == '0') return false;   // no leading zeroes
+        int n = Integer.parseInt(s);
+        return n >= 8 && n <= 15;
     }
 
     private static String unquote(String s) {
@@ -148,7 +190,8 @@ public class PerMessageDeflate {
      * Compress one message. RFC 7692 7.2.1: deflate with SYNC_FLUSH, then drop
      * the 4-octet {@code 00 00 FF FF} tail that the flush appends.
      */
-    public byte[] compress(byte[] data, int length) {
+    public synchronized byte[] compress(byte[] data, int length) {
+        if (ended) return EMPTY;
         deflater.setInput(data, 0, length);
         DynamicBytes out = new DynamicBytes(Math.max(64, length));
         byte[] buf = new byte[4096];
@@ -196,9 +239,18 @@ public class PerMessageDeflate {
      * Decompress one message. RFC 7692 7.2.2: append the tail the sender
      * removed, then inflate.
      */
-    public byte[] decompress(byte[] data) throws WebSocketException {
+    public synchronized byte[] decompress(byte[] data) throws WebSocketException {
+        // The connection is closing underneath us; fail the frame rather than
+        // touch a released Inflater.
+        if (ended) throw new WebSocketException(1001, "Connection closing");
         inflater.setInput(data);
-        DynamicBytes out = new DynamicBytes(Math.max(64, data.length * 4));
+        // Bounded, and not by data.length*4: that overflows to a negative
+        // capacity on a large :max-ws, and lets a peer force a 16 MiB
+        // allocation with a 4 MiB frame whose output is tiny. DynamicBytes
+        // grows as needed, so a modest start costs a copy at worst.
+        DynamicBytes out = new DynamicBytes(
+                Math.max(64, Math.min(data.length * 2L, maxSize) > Integer.MAX_VALUE
+                        ? 65536 : (int) Math.min(data.length * 2L, 65536)));
         byte[] buf = new byte[4096];
         try {
             inflate(out, buf);
@@ -230,8 +282,12 @@ public class PerMessageDeflate {
         }
     }
 
-    /** Release the native zlib state. Called when the connection closes. */
-    public void end() {
+    /** Release the native zlib state. Called when the connection closes, from
+     *  whichever thread closed it -- hence synchronized, and idempotent: both
+     *  onClose and serverClose can reach it. */
+    public synchronized void end() {
+        if (ended) return;
+        ended = true;
         deflater.end();
         inflater.end();
     }

--- a/src/java/org/httpkit/server/PerMessageDeflate.java
+++ b/src/java/org/httpkit/server/PerMessageDeflate.java
@@ -1,0 +1,238 @@
+package org.httpkit.server;
+
+import org.httpkit.DynamicBytes;
+
+import java.util.zip.DataFormatException;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+/**
+ * The "permessage-deflate" WebSocket extension, RFC 7692.
+ *
+ * <p>One instance per connection. Not thread-safe, and does not need to be:
+ * outbound frames are serialised by {@code AsyncChannel.send}, which is
+ * {@code synchronized}, and inbound frames are decoded on the single IO event
+ * thread that owns the connection's {@link WsAtta}.
+ *
+ * <h3>What is implemented</h3>
+ *
+ * Context takeover in both directions (the default, and the whole point of the
+ * extension: message N is compressed against messages 1..N-1, which is what
+ * makes a stream of many small similar messages compress at all). The
+ * {@code client_no_context_takeover} and {@code server_no_context_takeover}
+ * parameters are honoured when the client asks for them.
+ *
+ * <h3>What is not</h3>
+ *
+ * {@code server_max_window_bits} is declined. {@code java.util.zip} does not
+ * expose zlib's windowBits, so the server cannot honour a smaller window and
+ * must not claim to. Per RFC 7692 section 7.1.2.2 an offer whose
+ * {@code server_max_window_bits} we cannot satisfy is simply not accepted with
+ * that parameter -- we respond without it. {@code client_max_window_bits} IS
+ * accepted, because it constrains the client's deflater and our
+ * {@link Inflater} handles any window up to the 32 KiB maximum.
+ *
+ * <h3>Message size</h3>
+ *
+ * {@link WSDecoder} bounds the length of the bytes actually received. That
+ * bound does not survive inflation: a small compressed frame can expand
+ * enormously, so decompression is bounded separately here and aborts with the
+ * same 1009 status the decoder uses.
+ */
+public class PerMessageDeflate {
+
+    /** RFC 7692 7.2.1: DEFLATE emits this tail on a SYNC_FLUSH; it is removed
+     *  on compress and appended again before inflating. */
+    private static final byte[] TAIL = {0x00, 0x00, (byte) 0xFF, (byte) 0xFF};
+
+    public static final String NAME = "permessage-deflate";
+
+    private final Deflater deflater;
+    private final Inflater inflater;
+    private final boolean serverNoContextTakeover;
+    private final boolean clientNoContextTakeover;
+    private final int maxSize;
+
+    private PerMessageDeflate(boolean serverNoContextTakeover,
+                              boolean clientNoContextTakeover,
+                              int maxSize) {
+        // nowrap = raw DEFLATE, i.e. no zlib header or checksum. RFC 7692 is
+        // defined over raw deflate blocks.
+        this.deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        this.inflater = new Inflater(true);
+        this.serverNoContextTakeover = serverNoContextTakeover;
+        this.clientNoContextTakeover = clientNoContextTakeover;
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * Negotiate against a client's {@code Sec-WebSocket-Extensions} offer.
+     *
+     * @return null when permessage-deflate was not offered, or was offered only
+     *         with parameters this implementation cannot satisfy. A null result
+     *         means "no extension"; the connection then behaves exactly as it
+     *         did before this class existed.
+     */
+    public static PerMessageDeflate negotiate(String offer, int maxSize) {
+        if (offer == null) return null;
+
+        // The header is a comma-separated list of offers, each of which the
+        // server may accept or skip. Take the first one we can satisfy.
+        for (String candidate : offer.split(",")) {
+            String[] parts = candidate.trim().split(";");
+            if (parts.length == 0 || !NAME.equalsIgnoreCase(parts[0].trim())) {
+                continue;
+            }
+
+            boolean serverNoCtx = false, clientNoCtx = false, acceptable = true;
+            for (int i = 1; i < parts.length; i++) {
+                String p = parts[i].trim();
+                if (p.isEmpty()) continue;
+                int eq = p.indexOf('=');
+                String key = (eq < 0 ? p : p.substring(0, eq)).trim();
+                String val = eq < 0 ? null : unquote(p.substring(eq + 1).trim());
+
+                if ("server_no_context_takeover".equalsIgnoreCase(key)) {
+                    serverNoCtx = true;
+                } else if ("client_no_context_takeover".equalsIgnoreCase(key)) {
+                    clientNoCtx = true;
+                } else if ("client_max_window_bits".equalsIgnoreCase(key)) {
+                    // Accepted but not echoed: it constrains the CLIENT's
+                    // deflater, and our inflater copes with any legal window.
+                    if (val != null && !isWindowBits(val)) acceptable = false;
+                } else if ("server_max_window_bits".equalsIgnoreCase(key)) {
+                    // Cannot be honoured (see class docs). If the client merely
+                    // offered it we decline the parameter by not echoing it,
+                    // which per RFC 7692 means a 15-bit window. A value we do
+                    // not understand makes the whole offer unacceptable.
+                    if (val != null && !isWindowBits(val)) acceptable = false;
+                } else {
+                    // An unknown parameter must make the offer unacceptable
+                    // rather than be ignored -- ignoring it would mean agreeing
+                    // to terms we did not implement.
+                    acceptable = false;
+                }
+            }
+            if (acceptable) {
+                return new PerMessageDeflate(serverNoCtx, clientNoCtx, maxSize);
+            }
+        }
+        return null;
+    }
+
+    private static boolean isWindowBits(String s) {
+        try {
+            int n = Integer.parseInt(s);
+            return n >= 8 && n <= 15;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    private static String unquote(String s) {
+        if (s.length() >= 2 && s.charAt(0) == '"' && s.charAt(s.length() - 1) == '"') {
+            return s.substring(1, s.length() - 1);
+        }
+        return s;
+    }
+
+    /** The value to send back in {@code Sec-WebSocket-Extensions}. */
+    public String responseHeader() {
+        StringBuilder sb = new StringBuilder(NAME);
+        if (serverNoContextTakeover) sb.append("; server_no_context_takeover");
+        if (clientNoContextTakeover) sb.append("; client_no_context_takeover");
+        return sb.toString();
+    }
+
+    /**
+     * Compress one message. RFC 7692 7.2.1: deflate with SYNC_FLUSH, then drop
+     * the 4-octet {@code 00 00 FF FF} tail that the flush appends.
+     */
+    public byte[] compress(byte[] data, int length) {
+        deflater.setInput(data, 0, length);
+        DynamicBytes out = new DynamicBytes(Math.max(64, length));
+        byte[] buf = new byte[4096];
+        int n;
+        // SYNC_FLUSH rather than finish(): finishing would end the deflate
+        // stream and discard the history that context takeover exists to keep.
+        while ((n = deflater.deflate(buf, 0, buf.length, Deflater.SYNC_FLUSH)) > 0) {
+            out.append(buf, n);
+            if (n < buf.length) break;
+        }
+        if (serverNoContextTakeover) deflater.reset();
+
+        int len = out.length();
+        // Drop the tail the SYNC_FLUSH appended.
+        if (len >= TAIL.length && endsWithTail(out.get(), len)) {
+            len -= TAIL.length;
+        }
+        // RFC 7692 7.2.3.6: when the compressor produces nothing -- an empty
+        // message, or one whose content was already flushed -- the payload
+        // must be a single empty uncompressed DEFLATE block, 0x00, NOT zero
+        // bytes. "If the compression library being used doesn't generate any
+        // data when its buffer is empty, an empty uncompressed DEFLATE block
+        // can be built and used for this purpose as follows: 0x00".
+        //
+        // Zero bytes only misbehaves once there is compression history for it
+        // to corrupt: an empty message round-trips fine on a fresh connection
+        // and desynchronises the stream mid-conversation. Found by testing
+        // against an independent client implementation, not by reading.
+        if (len == 0) {
+            return new byte[]{0x00};
+        }
+        byte[] result = new byte[len];
+        System.arraycopy(out.get(), 0, result, 0, len);
+        return result;
+    }
+
+    private static boolean endsWithTail(byte[] bs, int len) {
+        for (int i = 0; i < TAIL.length; i++) {
+            if (bs[len - TAIL.length + i] != TAIL[i]) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Decompress one message. RFC 7692 7.2.2: append the tail the sender
+     * removed, then inflate.
+     */
+    public byte[] decompress(byte[] data) throws WebSocketException {
+        inflater.setInput(data);
+        DynamicBytes out = new DynamicBytes(Math.max(64, data.length * 4));
+        byte[] buf = new byte[4096];
+        try {
+            inflate(out, buf);
+            inflater.setInput(TAIL);
+            inflate(out, buf);
+        } catch (DataFormatException e) {
+            throw new WebSocketException(1002, "Invalid permessage-deflate payload: "
+                    + e.getMessage());
+        }
+        if (clientNoContextTakeover) inflater.reset();
+        byte[] result = new byte[out.length()];
+        System.arraycopy(out.get(), 0, result, 0, out.length());
+        return result;
+    }
+
+    private void inflate(DynamicBytes out, byte[] buf)
+            throws DataFormatException, WebSocketException {
+        int n;
+        while (!inflater.needsInput() && (n = inflater.inflate(buf)) > 0) {
+            // Bounded here and not only in WSDecoder: the decoder limits the
+            // bytes RECEIVED, which says nothing about the size after
+            // inflation. Without this, permessage-deflate would turn a small
+            // frame into an unbounded allocation.
+            if (out.length() + n > maxSize) {
+                throw new WebSocketException(1009,
+                        "Max payload length " + maxSize + " exceeded after decompression");
+            }
+            out.append(buf, n);
+        }
+    }
+
+    /** Release the native zlib state. Called when the connection closes. */
+    public void end() {
+        deflater.end();
+        inflater.end();
+    }
+}

--- a/src/java/org/httpkit/server/WSDecoder.java
+++ b/src/java/org/httpkit/server/WSDecoder.java
@@ -27,7 +27,7 @@ public class WSDecoder {
     private static final int RSV1 = 0x40;
 
     /** Null unless permessage-deflate was negotiated for this connection. */
-    private PerMessageDeflate perMessageDeflate;
+    private volatile PerMessageDeflate perMessageDeflate;
     /** Whether the message currently being assembled was sent compressed. */
     private boolean compressedMessage;
 
@@ -51,6 +51,8 @@ public class WSDecoder {
         this.maxSize = maxSize;
     }
 
+    /** Written from the handshake thread and from the close path, read on
+     *  the selector thread -- volatile so the null on close is actually seen. */
     public void setPerMessageDeflate(PerMessageDeflate pmd) {
         this.perMessageDeflate = pmd;
     }
@@ -243,7 +245,13 @@ public class WSDecoder {
     private byte[] inflateIfNeeded(byte[] data) throws ProtocolException {
         if (!compressedMessage) return data;
         compressedMessage = false;
-        return perMessageDeflate.decompress(data);
+        // Read ONCE. The close path nulls this field from another thread, so
+        // re-reading it after the check could dereference null.
+        PerMessageDeflate pmd = perMessageDeflate;
+        if (pmd == null) {
+            throw new ProtocolException("permessage-deflate codec released while decoding");
+        }
+        return pmd.decompress(data);
     }
 
     private void appendFrameContent() {

--- a/src/java/org/httpkit/server/WSDecoder.java
+++ b/src/java/org/httpkit/server/WSDecoder.java
@@ -23,6 +23,14 @@ public class WSDecoder {
 
     private final int maxSize;
 
+    /** RFC 7692 marks a compressed message by setting RSV1 on its FIRST frame. */
+    private static final int RSV1 = 0x40;
+
+    /** Null unless permessage-deflate was negotiated for this connection. */
+    private PerMessageDeflate perMessageDeflate;
+    /** Whether the message currently being assembled was sent compressed. */
+    private boolean compressedMessage;
+
     private State state = State.FRAME_START;
     private DynamicBytes content; // Content accumulated across fragmented data frames
     private byte[] frameContent;
@@ -41,6 +49,10 @@ public class WSDecoder {
 
     public WSDecoder(int maxSize) {
         this.maxSize = maxSize;
+    }
+
+    public void setPerMessageDeflate(PerMessageDeflate pmd) {
+        this.perMessageDeflate = pmd;
     }
 
     private boolean isAvailable(ByteBuffer src, int length) {
@@ -62,7 +74,11 @@ public class WSDecoder {
                     byte b = buffer.get(); // FIN, RSV, OPCODE
                     finalFlag = (b & 0x80) != 0;
 
-                    if ((b & 0x70) != 0) {
+                    // RSV1 is permessage-deflate's "this message is compressed"
+                    // bit and is legal only when the extension was negotiated.
+                    // RSV2/RSV3 remain unsupported.
+                    boolean rsv1 = (b & RSV1) != 0;
+                    if ((b & 0x30) != 0 || (rsv1 && perMessageDeflate == null)) {
                         throw new ProtocolException("unsupported websocket extension data");
                     }
 
@@ -71,15 +87,27 @@ public class WSDecoder {
                         throw new ProtocolException("unsupported websocket opcode: " + opcode);
                     }
                     if (isControlFrame(opcode)) {
+                        // RFC 7692 6.1: control frames are never compressed.
+                        if (rsv1) {
+                            throw new ProtocolException("compressed websocket control frame");
+                        }
                         if (!finalFlag) {
                             throw new ProtocolException("fragmented websocket control frame");
                         }
                     } else if (opcode == OPCODE_CONT) {
+                        // Continuations inherit the first frame's compression;
+                        // RSV1 must not be repeated on them.
+                        if (rsv1) {
+                            throw new ProtocolException(
+                                    "RSV1 set on websocket continuation frame");
+                        }
                         if (fragmentedOpCode == -1) {
                             throw new ProtocolException("unexpected websocket continuation frame");
                         }
                     } else if (fragmentedOpCode != -1) {
                         throw new ProtocolException("new data frame while fragmented message is open");
+                    } else {
+                        compressedMessage = rsv1;
                     }
                     state = State.READ_LENGTH;
                     break;
@@ -182,10 +210,14 @@ public class WSDecoder {
                                 byte[] completedContent = content.bytes();
                                 fragmentedOpCode = -1;
                                 content = null;
-                                return dataFrame(completedOpcode, completedContent);
+                                // Inflate the REASSEMBLED message, not each
+                                // fragment: the deflate stream spans the whole
+                                // message and a fragment is not independently
+                                // decodable.
+                                return dataFrame(completedOpcode, inflateIfNeeded(completedContent));
                             }
                         } else if (finalFlag) {
-                            return dataFrame(opcode, frameContent);
+                            return dataFrame(opcode, inflateIfNeeded(frameContent));
                         } else {
                             fragmentedOpCode = opcode;
                             content = new DynamicBytes(frameContent.length);
@@ -206,6 +238,12 @@ public class WSDecoder {
 
     private static boolean isControlFrame(int opcode) {
         return opcode >= OPCODE_CLOSE;
+    }
+
+    private byte[] inflateIfNeeded(byte[] data) throws ProtocolException {
+        if (!compressedMessage) return data;
+        compressedMessage = false;
+        return perMessageDeflate.decompress(data);
     }
 
     private void appendFrameContent() {

--- a/src/java/org/httpkit/server/WsAtta.java
+++ b/src/java/org/httpkit/server/WsAtta.java
@@ -9,5 +9,12 @@ public class WsAtta extends ServerAtta {
     public WsAtta(AsyncChannel channel, int maxSize) {
         this.decoder = new WSDecoder(maxSize);
         this.channel = channel;
+        // NOTE: the codec is NOT read here. This attachment is created while
+        // the upgrade REQUEST is decoded, which is before the Ring handler runs
+        // and therefore before the handshake has negotiated anything -- reading
+        // it here captured null, the decoder then rejected the client's first
+        // RSV1 frame as an unsupported extension, and the connection died.
+        // AsyncChannel.setPerMessageDeflate pushes it in once negotiation has
+        // actually happened.
     }
 }

--- a/src/org/httpkit/server.clj
+++ b/src/org/httpkit/server.clj
@@ -5,7 +5,7 @@
    [org.httpkit.utils :as utils])
 
   (:import
-   [org.httpkit.server AsyncChannel HttpServer RingHandler ProxyProtocolOption HttpServer$AddressFinder HttpServer$ServerChannelFactory Frame$PingFrame Frame$PongFrame]
+   [org.httpkit.server AsyncChannel HttpServer RingHandler ProxyProtocolOption HttpServer$AddressFinder HttpServer$ServerChannelFactory Frame$PingFrame Frame$PongFrame PerMessageDeflate]
    [org.httpkit.logger ContextLogger EventLogger EventNames]
    [java.net InetSocketAddress]
    [java.nio ByteBuffer]
@@ -218,6 +218,29 @@
 
 ;;;; WebSockets
 
+(def ^:dynamic *websocket-compression?*
+  "Whether to accept a client's RFC 7692 `permessage-deflate` offer.
+
+  Default true, and enabling it costs nothing when clients do not ask: the
+  extension is only ever active for a connection whose handshake offered it,
+  and a connection without it is byte-identical to one from before this
+  existed.
+
+  Bind to false to refuse compression -- worth doing when payloads are already
+  compressed (images, video), where deflate spends CPU to make them slightly
+  larger, or when per-connection memory matters more than bandwidth: context
+  takeover keeps a deflate and an inflate window alive for the life of each
+  connection."
+  true)
+
+(def ^:dynamic *websocket-max-message-size*
+  "Bound on a message's size AFTER decompression, in bytes.
+
+  Separate from the server's `:max-ws` option, which bounds the bytes actually
+  received. That bound says nothing about the size after inflation, so without
+  this a small compressed frame could expand without limit."
+  (* 4 1024 1024))
+
 (defn sec-websocket-accept [sec-websocket-key]
   (let [md (MessageDigest/getInstance "SHA1")
         websocket-13-guid "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"]
@@ -258,21 +281,42 @@
         (valid-websocket-key? sec-ws-key))
       (sec-websocket-accept sec-ws-key))))
 
+(defn- negotiate-permessage-deflate!
+  "Negotiates RFC 7692 permessage-deflate against the client's offer and, when
+  accepted, installs the codec on `ch`. Returns the value for the response's
+  `Sec-WebSocket-Extensions` header, or nil.
+
+  Compression is only ever enabled when the client asks for it, so a client
+  that does not offer the extension sees byte-identical behaviour to before.
+
+  Must run BEFORE the WsAtta is created, since that is what wires the codec
+  into the decoder."
+  [^AsyncChannel ch ring-req]
+  (when *websocket-compression?*
+    (when-let [pmd (PerMessageDeflate/negotiate
+                     (get-in ring-req [:headers "sec-websocket-extensions"])
+                     (int *websocket-max-message-size*))]
+      (.setPerMessageDeflate ch pmd)
+      (.responseHeader pmd))))
+
 (defn send-checked-websocket-handshake!
   "Given an AsyncChannel and `sec-ws-accept` string, unconditionally
   sends handshake to upgrade given AsyncChannel to a WebSocket.
   See also `websocket-handshake-check`."
-  [^AsyncChannel ch ^String sec-ws-accept]
-  (.sendHandshake ch
-    {"Upgrade" "websocket"
-     "Connection" "Upgrade"
-     "Sec-WebSocket-Accept" sec-ws-accept}))
+  ([^AsyncChannel ch ^String sec-ws-accept] (send-checked-websocket-handshake! ch sec-ws-accept nil))
+  ([^AsyncChannel ch ^String sec-ws-accept ring-req]
+   (let [ext (when ring-req (negotiate-permessage-deflate! ch ring-req))]
+     (.sendHandshake ch
+       (cond-> {"Upgrade" "websocket"
+                "Connection" "Upgrade"
+                "Sec-WebSocket-Accept" sec-ws-accept}
+         ext (assoc "Sec-WebSocket-Extensions" ext))))))
 
 (defn send-websocket-handshake!
   "Returns true iff successfully upgraded a valid WebSocket request."
   [^AsyncChannel ch ring-req]
   (when-let [sec-ws-accept (websocket-handshake-check ring-req)]
-    (send-checked-websocket-handshake! ch sec-ws-accept)
+    (send-checked-websocket-handshake! ch sec-ws-accept ring-req)
     true))
 
 ;;;; Channel API
@@ -353,7 +397,7 @@
      (if (:websocket? ring-req#)
        (if-let [sec-ws-accept# (websocket-handshake-check ring-req#)]
          (do
-           (send-checked-websocket-handshake! ~ch-name sec-ws-accept#)
+           (send-checked-websocket-handshake! ~ch-name sec-ws-accept# ring-req#)
            ~@body
            {:body ~ch-name})
          {:status 400 :body "Bad Sec-WebSocket-Key header"})
@@ -418,7 +462,7 @@
         (do
           (when-let [f on-receive] (org.httpkit.server/on-receive ch (partial f ch)))
           (when-let [f on-ping]    (org.httpkit.server/on-ping    ch (partial f ch)))
-          (send-checked-websocket-handshake! ch sec-ws-accept)
+          (send-checked-websocket-handshake! ch sec-ws-accept ring-req)
           (when-let [f on-open] (f ch)))
         (when-let [f on-handshake-error] (f ch)))
       (when-let [f on-open] (f ch)))
@@ -460,10 +504,12 @@
             (.setReceiveHandler   ch (fn [msg]         (wsp/on-message l sock (if (string? msg) msg (ByteBuffer/wrap msg)))))
             (.setCloseRingHandler ch (fn [code reason] (wsp/on-close   l sock code reason)))
 
-            (let [headers
-                  {"Upgrade"              "websocket"
-                   "Connection"           "Upgrade"
-                   "Sec-WebSocket-Accept" sec-ws-accept}]
+            (let [ext (negotiate-permessage-deflate! ch rreq)
+                  headers
+                  (cond-> {"Upgrade"              "websocket"
+                           "Connection"           "Upgrade"
+                           "Sec-WebSocket-Accept" sec-ws-accept}
+                    ext (assoc "Sec-WebSocket-Extensions" ext))]
 
               (.sendHandshake ch
                 (if-let [protocol (:ring.websocket/protocol rresp)]

--- a/test/org/httpkit/permessage_deflate_test.clj
+++ b/test/org/httpkit/permessage_deflate_test.clj
@@ -317,3 +317,51 @@
                 (finally (.end client))))
             (finally (.close ^java.net.Socket sock))))
         (finally (server))))))
+
+(deftest negotiation-grammar-is-strict
+  (testing "RFC 7692 7.1: an offer we cannot satisfy must be DECLINED, not
+            accepted with the offending parameter quietly dropped. Each of
+            these was accepted before."
+    (testing "server_max_window_bits must be declined outright — java.util.zip
+              does not expose windowBits, so we cannot honour a smaller window,
+              and accepting while omitting the parameter is not a valid
+              acceptance (7.1.2.1). A client sizing its inflate window at 1 KiB
+              against our 32 KiB-distance references corrupts silently."
+      (is (nil? (pmd "permessage-deflate; server_max_window_bits=10")))
+      (is (nil? (pmd "permessage-deflate; server_max_window_bits"))))
+
+    (testing "the no-context-takeover parameters take no value"
+      (is (nil? (pmd "permessage-deflate; server_no_context_takeover=x")))
+      (is (nil? (pmd "permessage-deflate; client_no_context_takeover=x"))))
+
+    (testing "duplicate parameter names must decline (7.1)"
+      (is (nil? (pmd "permessage-deflate; client_no_context_takeover; client_no_context_takeover"))))
+
+    (testing "window-bits values are 1*DIGIT, 8..15, no leading zeroes --
+              Integer.parseInt alone accepts \"08\" and \"+8\""
+      (is (nil? (pmd "permessage-deflate; client_max_window_bits=08")))
+      (is (nil? (pmd "permessage-deflate; client_max_window_bits=+8")))
+      (is (nil? (pmd "permessage-deflate; client_max_window_bits=7")))
+      (is (nil? (pmd "permessage-deflate; client_max_window_bits=16"))))
+
+    (testing "an empty parameter is not valid grammar"
+      (is (nil? (pmd "permessage-deflate;;"))))
+
+    (testing "and what browsers actually send is still accepted"
+      (is (some? (pmd "permessage-deflate; client_max_window_bits")))
+      (is (some? (pmd "permessage-deflate; client_max_window_bits=15")))
+      (is (some? (pmd "permessage-deflate")))
+      (is (some? (pmd "permessage-deflate; client_no_context_takeover")))
+      (testing "including skipping an unsatisfiable offer for a later one"
+        (is (some? (pmd "permessage-deflate; server_max_window_bits=10, permessage-deflate")))))))
+
+(deftest end-is-idempotent-and-safe
+  (testing "both close paths reach end(), and HttpServer.stop can close a
+            channel while the selector is still decoding, so end() must be
+            idempotent and must not leave a released Inflater reachable"
+    (let [p (pmd "permessage-deflate")]
+      (.end p)
+      (.end p)
+      (is (thrown? org.httpkit.server.WebSocketException
+                   (.decompress p (byte-array [0x00])))
+          "decompress after end fails cleanly rather than touching freed native memory"))))

--- a/test/org/httpkit/permessage_deflate_test.clj
+++ b/test/org/httpkit/permessage_deflate_test.clj
@@ -1,0 +1,319 @@
+(ns org.httpkit.permessage-deflate-test
+  "RFC 7692 permessage-deflate.
+
+  The negotiation and codec tests are unit-level because the interesting cases
+  are protocol edge cases -- a compressed control frame, RSV1 on a
+  continuation, an unknown extension parameter -- that are awkward to provoke
+  through a real client and trivial to state directly."
+  (:require
+   [clojure.test :refer :all]
+   [org.httpkit.server :as server]
+   [hato.websocket])
+  (:import
+   [org.httpkit.server PerMessageDeflate WSDecoder]
+   [org.httpkit ProtocolException]
+   [java.nio ByteBuffer]))
+
+(def ^:private max-size (* 1024 1024))
+
+(defn- ^PerMessageDeflate pmd [offer] (PerMessageDeflate/negotiate offer max-size))
+
+;;;; Negotiation
+
+(deftest negotiation-accepts-a-plain-offer
+  (let [p (pmd "permessage-deflate")]
+    (is (some? p))
+    (is (= "permessage-deflate" (.responseHeader p)))
+    (.end p)))
+
+(deftest negotiation-declines-when-not-offered
+  (is (nil? (pmd nil)) "no header at all")
+  (is (nil? (pmd "")) "empty header")
+  (is (nil? (pmd "x-webkit-deflate-frame")) "a DIFFERENT extension must not match"))
+
+(deftest negotiation-echoes-no-context-takeover
+  (testing "the parameters constrain BOTH ends, so an accepted one has to be
+            echoed or the peer and the server disagree about whether the
+            window persists -- which decodes as corruption, not as an error"
+    (let [p (pmd "permessage-deflate; client_no_context_takeover")]
+      (is (= "permessage-deflate; client_no_context_takeover" (.responseHeader p)))
+      (.end p))
+    (let [p (pmd "permessage-deflate; server_no_context_takeover; client_no_context_takeover")]
+      (is (= "permessage-deflate; server_no_context_takeover; client_no_context_takeover"
+             (.responseHeader p)))
+      (.end p))))
+
+(deftest negotiation-does-not-echo-window-bits
+  (testing "java.util.zip cannot set zlib's windowBits, so the server must not
+            claim a smaller window. Accepting the offer while omitting the
+            parameter means a 15-bit window, which is what we actually use."
+    (let [p (pmd "permessage-deflate; client_max_window_bits=10")]
+      (is (some? p) "the offer is still acceptable")
+      (is (= "permessage-deflate" (.responseHeader p)) "but the parameter is not echoed")
+      (.end p))
+    (let [p (pmd "permessage-deflate; client_max_window_bits")]
+      (is (some? p) "the valueless form is what browsers send")
+      (.end p))))
+
+(deftest negotiation-rejects-what-it-does-not-implement
+  (testing "an unknown parameter must make the offer unacceptable rather than
+            be ignored -- ignoring it means agreeing to terms we did not
+            implement, and the peer then encodes for a contract we are not
+            honouring"
+    (is (nil? (pmd "permessage-deflate; made_up_parameter")))
+    (is (nil? (pmd "permessage-deflate; client_max_window_bits=99")) "out of range")
+    (is (nil? (pmd "permessage-deflate; client_max_window_bits=abc")) "not a number")))
+
+(deftest negotiation-takes-the-first-acceptable-offer
+  (testing "clients may list several; skip the ones we cannot satisfy"
+    (let [p (pmd "permessage-deflate; made_up_parameter, permessage-deflate")]
+      (is (some? p))
+      (is (= "permessage-deflate" (.responseHeader p)))
+      (.end p))))
+
+;;;; The codec
+
+(defn- roundtrip [^PerMessageDeflate p ^String s]
+  (let [bs (.getBytes s "UTF-8")]
+    (String. (.decompress p (.compress p bs (alength bs))) "UTF-8")))
+
+(deftest codec-round-trips
+  (let [p (pmd "permessage-deflate")]
+    (try
+      (doseq [s ["" "a" "hello world"
+                 (apply str (repeat 1000 "compressible "))
+                 "unicode: äöü 中文 😀"]]
+        (is (= s (roundtrip p s)) (str "len " (count s))))
+      (finally (.end p)))))
+
+(deftest context-takeover-is-what-makes-it-worth-having
+  (testing "the whole point of the extension for a stream of small similar
+            messages: message N is compressed against 1..N-1. Without context
+            takeover each message pays full price, so the sizes must diverge."
+    (let [^bytes msg (.getBytes "{\"type\":\"publish\",\"topic\":\"store\",\"key\":\"node-1\"}" "UTF-8")
+          ^PerMessageDeflate with-ctx (pmd "permessage-deflate")
+          ^PerMessageDeflate without  (pmd "permessage-deflate; server_no_context_takeover")]
+      (try
+        (dotimes [_ 20] (.compress with-ctx msg (alength msg)))
+        (dotimes [_ 20] (.compress without  msg (alength msg)))
+        (let [a (alength (.compress with-ctx msg (alength msg)))
+              b (alength (.compress without  msg (alength msg)))]
+          (is (< a b)
+              (format "with context takeover %d B, without %d B" a b))
+          (is (< a (/ (alength msg) 4))
+              "a repeated message should collapse to a small back-reference"))
+        (finally (.end with-ctx) (.end without))))))
+
+(deftest decompression-is-bounded
+  (testing "WSDecoder bounds the bytes RECEIVED, which says nothing about the
+            size after inflation. Without a separate bound, a small frame is an
+            unbounded allocation."
+    (let [^PerMessageDeflate small (PerMessageDeflate/negotiate "permessage-deflate" 1024)
+          ^bytes big (byte-array 1000000)] ; all zeros: compresses to almost nothing
+      (try
+        (let [compressed (.compress small big (alength big))]
+          (is (< (alength compressed) 1024) "the compressed form is tiny")
+          (is (thrown-with-msg? Exception #"Max payload length"
+                                (.decompress small compressed))))
+        (finally (.end small))))))
+
+;;;; Decoder framing rules
+
+(defn- masked-frame
+  "A client->server frame. `b0` is the FIN/RSV/opcode byte."
+  [b0 ^bytes payload]
+  (let [^bytes mask (byte-array [1 2 3 4])
+        n (alength payload)
+        ^bytes masked (byte-array n)]
+    (dotimes [i n]
+      (aset masked i (byte (bit-xor (aget payload i) (aget mask (mod i 4))))))
+    (let [buf (ByteBuffer/allocate (+ 6 n))]
+      ;; unchecked-byte, not byte: the FIN/RSV bits put these above 127 and
+      ;; `byte` refuses to narrow them.
+      (.put buf (unchecked-byte b0))
+      (.put buf (unchecked-byte (bit-or 0x80 n)))   ; MASK + short length
+      (.put buf mask)
+      (.put buf masked)
+      (.flip buf)
+      buf)))
+
+(deftest rsv1-is-rejected-without-the-extension
+  (testing "unchanged behaviour for a connection that did not negotiate:
+            RSV1 stays a protocol error rather than becoming silently ignored"
+    (let [d (WSDecoder. max-size)]
+      (is (thrown? ProtocolException
+                   (.decode d (masked-frame 0xC1 (.getBytes "hi" "UTF-8"))))))))
+
+(deftest a-compressed-control-frame-is-rejected
+  (testing "RFC 7692 6.1 -- control frames are never compressed. Accepting one
+            would mean inflating a close/ping payload the peer never deflated."
+    (let [d (WSDecoder. max-size)
+          p (pmd "permessage-deflate")]
+      (.setPerMessageDeflate d p)
+      (try
+        (is (thrown-with-msg? ProtocolException #"compressed websocket control frame"
+                              (.decode d (masked-frame 0xC9 (byte-array 0)))))
+        (finally (.end p))))))
+
+(deftest rsv1-on-a-continuation-is-rejected
+  (testing "RSV1 belongs on the FIRST frame of a message only; a continuation
+            inherits it. Repeating it means the sender and receiver disagree
+            about where the deflate stream starts."
+    (let [d (WSDecoder. max-size)
+          p (pmd "permessage-deflate")]
+      (.setPerMessageDeflate d p)
+      (try
+        ;; open a fragmented message (FIN=0, opcode=BINARY, RSV1 set)
+        (.decode d (masked-frame 0x42 (byte-array 1)))
+        (is (thrown-with-msg? ProtocolException #"RSV1 set on websocket continuation"
+                              (.decode d (masked-frame 0x40 (byte-array 1)))))
+        (finally (.end p))))))
+
+(deftest rsv2-and-rsv3-stay-unsupported
+  (let [d (WSDecoder. max-size)
+        p (pmd "permessage-deflate")]
+    (.setPerMessageDeflate d p)
+    (try
+      (doseq [b0 [0xA1 0x91]] ; RSV2, RSV3
+        (is (thrown? ProtocolException (.decode d (masked-frame b0 (byte-array 1))))))
+      (finally (.end p)))))
+
+;;;; Opt-out
+
+(deftest compression-can-be-refused
+  (testing "already-compressed payloads and memory-sensitive servers want out;
+            binding the var off must make negotiation a no-op"
+    (binding [server/*websocket-compression?* false]
+      (is (nil? (#'server/negotiate-permessage-deflate!
+                 nil {:headers {"sec-websocket-extensions" "permessage-deflate"}}))))))
+
+;;;; End to end, over a real socket
+;;
+;; Hand-built rather than driven by a client library. The first version of this
+;; used hato, whose underlying java.net.http.WebSocket does NOT offer
+;; permessage-deflate -- so it passed while negotiating the extension away and
+;; proved nothing. Speaking the bytes directly is the only way to assert that
+;; RSV1 actually appears on the wire.
+
+(defn- ws-handshake!
+  "Opens a socket, sends an upgrade request offering permessage-deflate, and
+  returns [socket in out response-headers]."
+  [port]
+  (let [sock (java.net.Socket. "localhost" (int port))
+        out (.getOutputStream sock)
+        in (java.io.DataInputStream. (.getInputStream sock))]
+    (.write out (.getBytes (str "GET / HTTP/1.1\r\n"
+                                "Host: localhost\r\n"
+                                "Upgrade: websocket\r\n"
+                                "Connection: Upgrade\r\n"
+                                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                                "Sec-WebSocket-Version: 13\r\n"
+                                "Sec-WebSocket-Extensions: permessage-deflate\r\n"
+                                "\r\n")
+                           "UTF-8"))
+    (.flush out)
+    (let [headers (loop [acc []]
+                    (let [line (.readLine in)]
+                      (if (or (nil? line) (= "" line)) acc (recur (conj acc line)))))]
+      [sock in out headers])))
+
+(defn- send-masked!
+  "Write a client->server frame with FIN set, `rsv1` optional."
+  [^java.io.OutputStream out opcode ^bytes payload rsv1]
+  (let [n (alength payload)
+        mask (byte-array [9 8 7 6])
+        buf (java.io.ByteArrayOutputStream.)]
+    (.write buf (unchecked-byte (bit-or 0x80 (if rsv1 0x40 0) opcode)))
+    (.write buf (unchecked-byte (bit-or 0x80 n)))   ; assumes n <= 125
+    (.write buf mask)
+    (dotimes [i n]
+      (.write buf (unchecked-byte (bit-xor (aget payload i) (aget mask (mod i 4))))))
+    (.write out (.toByteArray buf))
+    (.flush out)))
+
+(defn- read-frame!
+  "Read one server->client frame (unmasked). Returns [rsv1? payload]."
+  [^java.io.DataInputStream in]
+  (let [b0 (.readUnsignedByte in)
+        b1 (.readUnsignedByte in)
+        n (bit-and b1 0x7F)
+        n (cond (= n 126) (.readUnsignedShort in)
+                (= n 127) (int (.readLong in))
+                :else n)
+        payload (byte-array n)]
+    (.readFully in payload)
+    [(not= 0 (bit-and b0 0x40)) payload]))
+
+(deftest ^:integration compressed-frames-cross-a-real-socket
+  (testing "the whole path: the server accepts the offer in the handshake, sets
+            RSV1 on what it sends back, and both directions inflate."
+    (let [negotiated (atom :never-connected)
+          server (server/run-server
+                  (fn [req]
+                    (server/as-channel
+                     req
+                     {:on-open (fn [ch]
+                                 (reset! negotiated
+                                         (some? (.getPerMessageDeflate
+                                                 ^org.httpkit.server.AsyncChannel ch))))
+                      :on-receive (fn [ch msg] (server/send! ch msg))}))
+                  {:port 0 :join? false})
+          port (:local-port (meta server))]
+      (try
+        (let [[sock in out headers] (ws-handshake! port)
+              ext (some #(when (re-find #"(?i)^Sec-WebSocket-Extensions:" %) %) headers)]
+          (try
+            (is (some? ext) "the server echoed Sec-WebSocket-Extensions")
+            (is (re-find #"permessage-deflate" ext))
+            (is (true? @negotiated) "and installed the codec on the channel")
+
+            ;; A second instance stands in for the client's half of the
+            ;; connection; deflate/inflate are symmetric.
+            (let [client (pmd "permessage-deflate")]
+              (try
+                (dotimes [i 20]
+                  (let [^bytes msg (.getBytes (str "{\"key\":\"node-" i "\"}") "UTF-8")
+                        deflated (.compress client msg (alength msg))]
+                    (send-masked! out 0x01 deflated true)
+                    (let [[rsv1 echoed] (read-frame! in)]
+                      (is rsv1 (str "server set RSV1 on echo " i))
+                      (is (= (String. msg "UTF-8")
+                             (String. (.decompress client echoed) "UTF-8"))))))
+                (finally (.end client))))
+            (finally (.close ^java.net.Socket sock))))
+        (finally (server))))))
+
+(deftest empty-message-mid-stream
+  (testing "RFC 7692 7.2.3.6: a message whose compressed form is empty must go
+            out as the single octet 0x00, not as zero bytes.
+
+            This is a regression test for a real interop defect. Zero bytes
+            round-trips fine on a fresh connection and as the FIRST message,
+            because there is no compression history yet for it to corrupt. Send
+            [\"a\" \"\" \"b\"] over one connection with context takeover and the
+            stream desynchronises: \"b\" never arrives. It was found by running
+            this server against an independent client implementation, which is
+            the only reason it surfaced at all -- one implementation talking to
+            itself agrees with itself either way."
+    (let [server (server/run-server
+                  (fn [req]
+                    (server/as-channel req {:on-receive (fn [ch msg] (server/send! ch msg))}))
+                  {:port 0 :join? false})
+          port (:local-port (meta server))]
+      (try
+        (let [[sock in out _headers] (ws-handshake! port)]
+          (try
+            (let [client (pmd "permessage-deflate")]
+              (try
+                (doseq [s ["a" "" "b" "" "" "c"]]
+                  (let [^bytes msg (.getBytes ^String s "UTF-8")
+                        deflated (.compress client msg (alength msg))]
+                    (is (pos? (alength deflated))
+                        (str "compressed payload for " (pr-str s) " is never zero-length"))
+                    (send-masked! out 0x01 deflated true)
+                    (let [[_rsv1 echoed] (read-frame! in)]
+                      (is (= s (String. (.decompress client echoed) "UTF-8"))
+                          (str "round-trip of " (pr-str s) " in sequence")))))
+                (finally (.end client))))
+            (finally (.close ^java.net.Socket sock))))
+        (finally (server))))))


### PR DESCRIPTION
Adds the `permessage-deflate` WebSocket extension to the server, with context
takeover.

Off unless the client offers it — a connection that does not negotiate the
extension takes the same code path it did before, so this should be inert for
existing users.

## Why context takeover

Compressing each message independently saves ~10% on small messages and is
barely worth the CPU. Context takeover — message N compressed against messages
1..N-1 — is what makes the extension pay for a stream of many similar messages.
On a sample of 500 small JSON-ish messages: **88 624 → 10 783 bytes (-88%)**.

That is also the motivation: a WebSocket carrying a stream of structurally
similar messages (RPC, replication, telemetry) is exactly the shape this helps,
and browsers offer the extension automatically, so it costs the application
nothing to benefit.

## Public surface

Two dynamic vars in `org.httpkit.server`:

- `*websocket-compression?*` (default true) — bind to false to refuse the
  offer. Worth doing when payloads are already compressed (images, video),
  where deflate spends CPU to make them slightly larger, or when per-connection
  memory matters more than bandwidth: context takeover keeps a deflate and an
  inflate window alive for the life of each connection.
- `*websocket-max-message-size*` — bounds a message's size **after**
  decompression. This is deliberately separate from `:max-ws`, which bounds the
  bytes actually received and therefore says nothing about the size after
  inflation; a small compressed frame can expand enormously. Exceeding it
  closes with 1009, the same status `WSDecoder` already uses.

## What is not implemented

`server_max_window_bits`. `java.util.zip` does not expose zlib's windowBits, so
the server cannot honour a smaller window and does not claim to — the parameter
is simply not echoed, which per RFC 7692 §7.1.2.2 means a 15-bit window.
`client_max_window_bits` is accepted, since it constrains the client's deflater
and `Inflater` copes with any legal window.

`client_no_context_takeover` and `server_no_context_takeover` are both honoured
when offered. An unknown parameter makes an offer unacceptable rather than
being ignored — ignoring it would mean agreeing to terms we did not implement.

## Implementation notes

`PerMessageDeflate` is one instance per connection and is not thread-safe,
which it does not need to be: outbound frames are serialised by
`AsyncChannel.send` (already `synchronized`), and inbound frames are decoded on
the single IO thread owning the connection's `WsAtta`.

`negotiate` returns null when the extension was not offered or was offered only
with parameters it cannot satisfy; null means "no extension" and the connection
behaves exactly as before.

## Testing

15 tests / 73 assertions covering negotiation (including offer lists,
unknown-parameter rejection, and both no-context-takeover directions),
round-trips with and without context takeover, RSV1 handling, fragmented
messages, control frames interleaved with compressed data, and the
post-inflation size bound. Driven through a real socket against a running
server rather than by calling the class directly.

Full suite green: 154 tests / 7330 assertions.